### PR TITLE
Add CC 90 to definitions added when compiling with NVMOLKIT_CUDA_TARGETS=native

### DIFF
--- a/cmake/cuda_targets.cmake
+++ b/cmake/cuda_targets.cmake
@@ -108,7 +108,7 @@ if(CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
     message(FATAL_ERROR "Failed to build detect_cuda_arch.cu")
   endif()
   # _native_cc will be something like "86"
-  foreach(cc IN ITEMS 80 86 89)
+  foreach(cc IN ITEMS 80 86 89 90)
     if(_native_cc STREQUAL "${cc}")
       add_definitions(-DNVMOLKIT_CUDA_CC_${cc}=1)
     else()


### PR DESCRIPTION
When compiling with `-DNVMOLKIT_CUDA_TARGETS=native` the build fails since 90 is missing from the CC list in `cuda_targets.cmake`, and it is explicitly checked for in `src/similarity_kernels.cu` This is a trivial fix.