### PR TITLE
Remove raw usages of cudaSetDevice, and fix sync on fingerprint tests

### DIFF
--- a/nvmolkit/tests/test_fingerprints.py
+++ b/nvmolkit/tests/test_fingerprints.py
@@ -54,6 +54,7 @@ def test_nvmolkit_fingerprint_throws_on_invalid_fpsize(fpSize, size_limited_mols
 def test_empty_input():
     fpgen = MorganFingerprintGenerator(radius=3, fpSize=2048)
     fps = fpgen.GetFingerprints([]).torch()
+    torch.cuda.synchronize()
     assert fps.shape == (0, 2048 // 32)
 
 def test_invalid_input():
@@ -70,6 +71,7 @@ def test_nvmolkit_morgan_fingerprint(size_limited_mols, fpSize, radius):
 
     nvmolkit_fpgen = MorganFingerprintGenerator(radius=radius, fpSize=fpSize)
     nvmolkit_fps_torch =  nvmolkit_fpgen.GetFingerprints(size_limited_mols).torch()
+    torch.cuda.synchronize()
     assert nvmolkit_fps_torch.device.type == 'cuda'
     want_n_rows = len(size_limited_mols)
     want_n_cols = fpSize / 32

--- a/src/etkdg.cpp
+++ b/src/etkdg.cpp
@@ -163,8 +163,8 @@ void embedMolecules(const std::vector<RDKit::ROMol*>&           mols,
   // Assign streams to the specified GPU devices
   const int numThreadsGpuBatching = effectivebatchesPerGpu * static_cast<int>(gpuIdsToUse.size());
   for (int i = 0; i < numThreadsGpuBatching; ++i) {
-    const int deviceId = gpuIdsToUse[i % gpuIdsToUse.size()];
-    cudaCheckError(cudaSetDevice(deviceId));
+    const int        deviceId = gpuIdsToUse[i % gpuIdsToUse.size()];
+    const WithDevice dev(deviceId);
     streamsPerThread.emplace_back();
     devicesPerThread.push_back(deviceId);
   }
@@ -211,9 +211,9 @@ void embedMolecules(const std::vector<RDKit::ROMol*>&           mols,
         }
         break;
       }
-      cudaStream_t streamPtr = streamsPerThread[omp_get_thread_num()].stream();
-      const int    deviceId  = devicesPerThread[omp_get_thread_num()];
-      cudaCheckError(cudaSetDevice(deviceId));
+      cudaStream_t     streamPtr = streamsPerThread[omp_get_thread_num()].stream();
+      const int        deviceId  = devicesPerThread[omp_get_thread_num()];
+      const WithDevice dev(deviceId);
 
       // Create batch of molecules and eargs for the dispatched work
       std::vector<RDKit::ROMol*>     batchMolsWithConfs;

--- a/src/morgan_fingerprint_gpu.cpp
+++ b/src/morgan_fingerprint_gpu.cpp
@@ -273,8 +273,8 @@ AsyncDeviceVector<FlatBitVect<fpSize>> computeFingerprintsCuImpl(const std::vect
   for (size_t i = 0; i < numThreadsTotal; i++) {
     std::vector<std::pair<FlatBitVect<fpSize>, int>> largeResults;
 
-    auto& threadCpuBuffers = threadBuffers[omp_get_thread_num()];
-
+    auto&             threadCpuBuffers = threadBuffers[omp_get_thread_num()];
+    const WithDevice  dev(0);
     // Do large molecules while we're waiting for the previous cycle, if possible
     const std::string rangeName =
       "LargeMolecules processing during downtime in main run thread " + std::to_string(omp_get_thread_num());


### PR DESCRIPTION
This fixes a possible error where ETKDG or MMFF did not reset the device after dispatching streams on the initial thread. This could lead to downstream errors in fingerprinting or TS where data allocations and memcpy options were targeting incorrect devices. Would only happen on the same process, such as pytest over the codebase.

The sync issue is separate