### PR TITLE
Fix incorrect packing of fingerprints, improve similarity tests

### DIFF
--- a/nvmolkit/tests/conftest.py
+++ b/nvmolkit/tests/conftest.py
@@ -26,9 +26,10 @@ def one_hundred_smiles():
     Returns:
         list: A list of one hundred SMILES strings.
     """
-    path = os.path.join(os.path.dirname(__file__), 'testdata', 'smiles.csv')
+    path = os.path.join(os.path.dirname(__file__), "testdata", "smiles.csv")
     df = pd.read_csv(path)
-    return df['smiles'].tolist()
+    return df["smiles"].tolist()
+
 
 @pytest.fixture
 def one_hundred_mols(one_hundred_smiles):
@@ -42,6 +43,7 @@ def one_hundred_mols(one_hundred_smiles):
     """
     return [Chem.MolFromSmiles(smi) for smi in one_hundred_smiles]
 
+
 @pytest.fixture
 def size_limited_mols(one_hundred_mols):
     """Generate RDKit molecules from one hundred smiles and discard any that have more than 128 atoms or bonds.
@@ -52,4 +54,4 @@ def size_limited_mols(one_hundred_mols):
     Returns:
         list: A list of RDKit molecules with at most 128 atoms and bonds. Up to 100 molecules are returned.
     """
-    return [mol for mol in one_hundred_mols if mol.GetNumAtoms() <= 128 and mol.GetNumBonds() <=128]
+    return [mol for mol in one_hundred_mols if mol.GetNumAtoms() <= 128 and mol.GetNumBonds() <= 128]

--- a/nvmolkit/tests/test_fingerprints.py
+++ b/nvmolkit/tests/test_fingerprints.py
@@ -45,6 +45,10 @@ def test_pack_unpack_uneven_size():
     assert unpacked.shape == (n_fps, 128)
     torch.testing.assert_close(test_fp, unpacked[:, :fp_size])
 
+def test_unpack_invalid_dtype():
+    with pytest.raises(ValueError):
+        unpack_fingerprint(torch.randint(0, 2, (10, 32), device='cuda', dtype=torch.int64))
+
 @pytest.mark.parametrize('fpSize', (17, 8192))
 def test_nvmolkit_fingerprint_throws_on_invalid_fpsize(fpSize, size_limited_mols):
     fpgen = MorganFingerprintGenerator(radius=3, fpSize=fpSize)


### PR DESCRIPTION
Packing FPs had been adding a bunch of zeros via implicit conversion to int64. Added a test in similarity to make sure packed fingerprints work.

Removed some redundant test cases and added larger size test cases to make sure we're exercising multi-block execution.

Fixes #10 