### PR TITLE
Fix -Werror warnings with gcc 13 and CUDA 13.1

### DIFF
--- a/src/substruct/molecules.cpp
+++ b/src/substruct/molecules.cpp
@@ -1832,9 +1832,9 @@ int collectPatternsFromMolecule(const RDKit::ROMol*                 mol,
                                 std::vector<RecursivePatternEntry>& patterns,
                                 int&                                nextPatternId,
                                 int                                 parentIdx,
-                                int                                 parentAtomIdx,
-                                int                                 currentDepth,
-                                int&                                nextLocalId) {
+                                int /* parentAtomIdx */,
+                                int  currentDepth,
+                                int& nextLocalId) {
   int                                maxDepth = 0;
   std::vector<PendingRecursiveChild> pendingChildren;
   for (const auto* atom : mol->atoms()) {

--- a/src/substruct/substruct_search_internal.h
+++ b/src/substruct/substruct_search_internal.h
@@ -277,7 +277,7 @@ class FallbackQueueProducerGuard {
 // Batch Results Accumulation
 // =============================================================================
 
-class GpuExecutor;
+struct GpuExecutor;
 struct PinnedHostBuffer;
 
 /**

--- a/src/utils/nvtx.h
+++ b/src/utils/nvtx.h
@@ -55,7 +55,7 @@ class ScopedNvtxRange {
 
  private:
   void pushWithColor(const char* name, uint32_t color) {
-    nvtxEventAttributes_t attrib = {0};
+    nvtxEventAttributes_t attrib = {};
     attrib.version               = NVTX_VERSION;
     attrib.size                  = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
     attrib.colorType             = NVTX_COLOR_ARGB;

--- a/tests/test_boolean_tree.cu
+++ b/tests/test_boolean_tree.cu
@@ -1129,20 +1129,6 @@ AtomDataPacked makeAtomWithMinRingSize(uint8_t ringSize) {
   return atom;
 }
 
-AtomDataPacked makeAtomWithNumRings(uint8_t numRings) {
-  AtomDataPacked atom;
-  atom.setAtomicNum(6);
-  atom.setNumRings(numRings);
-  return atom;
-}
-
-AtomDataPacked makeAtomWithTotalValence(uint8_t valence) {
-  AtomDataPacked atom;
-  atom.setAtomicNum(6);
-  atom.setTotalValence(valence);
-  return atom;
-}
-
 }  // namespace
 
 TEST(EvaluateBoolTreeTest, GreaterThanDegreeTrue) {

--- a/tests/test_flat_bit_vect_device.cu
+++ b/tests/test_flat_bit_vect_device.cu
@@ -263,7 +263,7 @@ TEST(BitMatrix2DViewDevice, Clear) {
   deviceStorage.copyToHost(hostResult);
   cudaCheckError(cudaStreamSynchronize(stream.stream()));
 
-  for (int i = 0; i < kRows * kCols; ++i) {
+  for (size_t i = 0; i < kRows * kCols; ++i) {
     EXPECT_FALSE(hostResult[0][i]) << "Bit " << i << " should be cleared";
   }
 }
@@ -329,8 +329,8 @@ TEST(BitMatrix2DViewDevice, LargeMatrix) {
   deviceStorage.setFromVector(std::vector<FlatBitVect<kRows * kCols>>{hostStorage});
 
   // Set a pattern: every (row, col) where row == col * 2
-  for (int col = 0; col < kCols; ++col) {
-    int row = col * 2;
+  for (size_t col = 0; col < kCols; ++col) {
+    size_t row = col * 2;
     if (row < kRows) {
       setMatrix2DKernel<kRows, kCols><<<1, 1, 0, stream.stream()>>>(deviceStorage.data(), row, col, true);
     }
@@ -343,8 +343,8 @@ TEST(BitMatrix2DViewDevice, LargeMatrix) {
   cudaCheckError(cudaStreamSynchronize(stream.stream()));
 
   BitMatrix2DView<kRows, kCols> view(hostResult[0]);
-  for (int row = 0; row < kRows; ++row) {
-    for (int col = 0; col < kCols; ++col) {
+  for (size_t row = 0; row < kRows; ++row) {
+    for (size_t col = 0; col < kCols; ++col) {
       bool expected = (row == col * 2);
       EXPECT_EQ(view.get(row, col), expected) << "Mismatch at (" << row << ", " << col << ")";
     }

--- a/tests/test_graph_labeler_recursive.cu
+++ b/tests/test_graph_labeler_recursive.cu
@@ -248,12 +248,12 @@ TEST_F(RecursiveInstructionTest, NegatedRecursivePattern) {
 
 class RecursivePaintTest : public ::testing::Test {
  protected:
-  ScopedStream                                 stream_;
-  std::unique_ptr<MiniBatchResultsDevice>      results_;
-  std::unique_ptr<AsyncDeviceVector<int>>      pairMatchStartsDev_;
-  int                                          maxTargetAtoms_ = 0;
-  int                                          numTargets_     = 0;
-  int                                          numQueries_     = 1;
+  ScopedStream                            stream_;
+  std::unique_ptr<MiniBatchResultsDevice> results_;
+  std::unique_ptr<AsyncDeviceVector<int>> pairMatchStartsDev_;
+  int                                     maxTargetAtoms_ = 0;
+  int                                     numTargets_     = 0;
+  int                                     numQueries_     = 1;
 
   void setupResults(const MoleculesHost& targetsHost, int numQueries = 1) {
     const int numTargets = static_cast<int>(targetsHost.numMolecules());
@@ -297,8 +297,8 @@ class RecursivePaintTest : public ::testing::Test {
   }
 
   void preprocessRecursive(const MoleculesDevice& targetDevice,
-                           const MoleculesHost&   targetHost,
-                           const RDKit::ROMol*    queryMol) {
+                           const MoleculesHost& /* targetHost */,
+                           const RDKit::ROMol* queryMol) {
     MoleculesHost queryHost;
     addQueryToBatch(queryMol, queryHost);
 

--- a/tests/test_substruct_integration.cu
+++ b/tests/test_substruct_integration.cu
@@ -82,11 +82,13 @@ std::vector<int> getAllGpuIds() {
   return ids;
 }
 
+// clang-format off
 const ThreadingConfig kThreadingConfigs[] = {
-  {nvMolKit::SubstructSearchConfig{.batchSize = 1024, .workerThreads = 1, .preprocessingThreads = 1}, "SingleThreaded"},
-  { nvMolKit::SubstructSearchConfig{.batchSize = 256, .workerThreads = 2, .preprocessingThreads = 4},  "MultiThreaded"},
-  {                                                nvMolKit::SubstructSearchConfig{.batchSize = 256},     "Autoselect"},
+  {nvMolKit::SubstructSearchConfig{.batchSize = 1024, .workerThreads = 1, .preprocessingThreads = 1, .executorsPerRunner = -1, .gpuIds = {}}, "SingleThreaded"},
+  {nvMolKit::SubstructSearchConfig{.batchSize = 256,  .workerThreads = 2, .preprocessingThreads = 4, .executorsPerRunner = -1, .gpuIds = {}}, "MultiThreaded"},
+  {nvMolKit::SubstructSearchConfig{.batchSize = 256,                                                  .executorsPerRunner = -1, .gpuIds = {}}, "Autoselect"},
 };
+// clang-format on
 
 constexpr DatasetConfig kDatasets[] = {
   {           "pwalters_alert_collection_supported.txt",            "PwaltersAlertCollection"},

--- a/tests/test_substruct_search.cu
+++ b/tests/test_substruct_search.cu
@@ -1103,7 +1103,7 @@ TEST_P(SubstructureSearchTest, ImpossibleAtomConstraint) {
   // This is contradictory and should never match anything
   const std::string query = "[C;a]";
 
-  for (const std::string& target : {"CCCCC", "c1ccccc1"}) {
+  for (const auto& target : {"CCCCC", "c1ccccc1"}) {
     std::vector<std::unique_ptr<RDKit::ROMol>> targetMols;
     std::vector<std::unique_ptr<RDKit::ROMol>> queryMols;
 
@@ -1125,7 +1125,7 @@ TEST_P(SubstructureSearchTest, ImpossibleChargeConstraint) {
   // [OX1;+0;-1] has charge +0 AND charge -1 in an AND, which is contradictory
   const std::string query = "[OX1;+0;-1]";
 
-  for (const std::string& target : {"O=S(=O)(CCO)c1ccccc1", "[O-]C"}) {
+  for (const auto& target : {"O=S(=O)(CCO)c1ccccc1", "[O-]C"}) {
     std::vector<std::unique_ptr<RDKit::ROMol>> targetMols;
     std::vector<std::unique_ptr<RDKit::ROMol>> queryMols;
 


### PR DESCRIPTION
Address compilation warnings promoted to errors by -Werror:

- nvtx.h: Use {} instead of {0} for nvtxEventAttributes_t initialization to fix -Wmissing-field-initializers
- molecules.cpp: Comment out unused parameter parentAtomIdx to fix -Wunused-parameter
- substruct_search_internal.h: Change forward declaration from class to struct to match definition, fixing -Wmismatched-tags
- test_boolean_tree.cu: Remove unused functions makeAtomWithNumRings and makeAtomWithTotalValence (NVCC error #177)
- test_flat_bit_vect_device.cu: Change int loop variables to size_t to match constexpr std::size_t bounds, fixing -Wsign-compare
- test_graph_labeler_recursive.cu: Comment out unused parameter targetHost to fix -Wunused-parameter
- test_substruct_integration.cu: Add explicit .executorsPerRunner and .gpuIds fields to designated initializers to fix -Wmissing-field-initializers
- test_substruct_search.cu: Change const std::string& to const auto& in range-for over initializer_list to fix -Wrange-loop-construct