### PR TITLE
Fix GetFingerprintsGpuBuffer callers for new stream parameter

### DIFF
--- a/benchmarks/morgan_fp.cpp
+++ b/benchmarks/morgan_fp.cpp
@@ -302,22 +302,22 @@ int main(const int argc, char* argv[]) {
     runOrOnce(useNanobench, title, [&] {
       switch (fpSize) {
         case 128:
-          ankerl::nanobench::doNotOptimizeAway(nvmolkitGen.GetFingerprintsGpuBuffer<128>(mols, options));
+          ankerl::nanobench::doNotOptimizeAway(nvmolkitGen.GetFingerprintsGpuBuffer<128>(mols, nullptr, options));
           break;
         case 256:
-          ankerl::nanobench::doNotOptimizeAway(nvmolkitGen.GetFingerprintsGpuBuffer<256>(mols, options));
+          ankerl::nanobench::doNotOptimizeAway(nvmolkitGen.GetFingerprintsGpuBuffer<256>(mols, nullptr, options));
           break;
         case 512:
-          ankerl::nanobench::doNotOptimizeAway(nvmolkitGen.GetFingerprintsGpuBuffer<512>(mols, options));
+          ankerl::nanobench::doNotOptimizeAway(nvmolkitGen.GetFingerprintsGpuBuffer<512>(mols, nullptr, options));
           break;
         case 1024:
-          ankerl::nanobench::doNotOptimizeAway(nvmolkitGen.GetFingerprintsGpuBuffer<1024>(mols, options));
+          ankerl::nanobench::doNotOptimizeAway(nvmolkitGen.GetFingerprintsGpuBuffer<1024>(mols, nullptr, options));
           break;
         case 2048:
-          ankerl::nanobench::doNotOptimizeAway(nvmolkitGen.GetFingerprintsGpuBuffer<2048>(mols, options));
+          ankerl::nanobench::doNotOptimizeAway(nvmolkitGen.GetFingerprintsGpuBuffer<2048>(mols, nullptr, options));
           break;
         case 4096:
-          ankerl::nanobench::doNotOptimizeAway(nvmolkitGen.GetFingerprintsGpuBuffer<4096>(mols, options));
+          ankerl::nanobench::doNotOptimizeAway(nvmolkitGen.GetFingerprintsGpuBuffer<4096>(mols, nullptr, options));
           break;
         default:
           throw std::runtime_error("Unsupported fp_size. Must be one of {128,256,512,1024,2048,4096}");

--- a/tests/integration/test_fp_sim_workflow.cpp
+++ b/tests/integration/test_fp_sim_workflow.cpp
@@ -50,7 +50,7 @@ TEST(FingerprintSimIntegrationTest, Basics) {
   // Compute fingerprints
   nvMolKit::FingerprintComputeOptions options;
   options.backend      = nvMolKit::FingerprintComputeBackend::GPU;
-  auto gpuFingerprints = generator.GetFingerprintsGpuBuffer<fpSize>(molsView, options);
+  auto gpuFingerprints = generator.GetFingerprintsGpuBuffer<fpSize>(molsView, nullptr, options);
   std::vector<std::unique_ptr<ExplicitBitVect>> refFingerprints;
   for (size_t i = 0; i < mols.size(); i++) {
     const auto& mol            = mols[i];

--- a/tests/test_morgan_fingerprint.cpp
+++ b/tests/test_morgan_fingerprint.cpp
@@ -246,7 +246,7 @@ TEST(MorganFingerprintGpuTest, ThrowsRequestingCpuBackendGpuBuffer) {
   auto                                generator = nvMolKit::MorganFingerprintGenerator(radius, fpSize);
   nvMolKit::FingerprintComputeOptions options;
   options.backend = nvMolKit::FingerprintComputeBackend::CPU;
-  ASSERT_THROW(generator.GetFingerprintsGpuBuffer<1024>({Singlemol.get()}, options), std::runtime_error);
+  ASSERT_THROW(generator.GetFingerprintsGpuBuffer<1024>({Singlemol.get()}, nullptr, options), std::runtime_error);
 }
 
 TEST(MorganFingerprintGpuTest, GpuBufferSameResult) {
@@ -259,7 +259,7 @@ TEST(MorganFingerprintGpuTest, GpuBufferSameResult) {
   nvMolKit::FingerprintComputeOptions options;
   options.backend = nvMolKit::FingerprintComputeBackend::GPU;
 
-  auto gpuResults = generator.GetFingerprintsGpuBuffer<fpSize>(molsView, options);
+  auto gpuResults = generator.GetFingerprintsGpuBuffer<fpSize>(molsView, nullptr, options);
   cudaDeviceSynchronize();
 
   std::vector<nvMolKit::FlatBitVect<fpSize>> gpuResultsHost(gpuResults.size());
@@ -324,8 +324,8 @@ TEST_P(MorganFingerprintParametrizedTest, MultipleCallsWithDifferenThreads) {
   }
 
   if (backend == nvMolKit::FingerprintComputeBackend::GPU) {
-    auto gpuResultsTry1 = generator.GetFingerprintsGpuBuffer<1024>(molsView, options);
-    auto gpuResultsTry2 = generator.GetFingerprintsGpuBuffer<1024>(molsView, options);
+    auto gpuResultsTry1 = generator.GetFingerprintsGpuBuffer<1024>(molsView, nullptr, options);
+    auto gpuResultsTry2 = generator.GetFingerprintsGpuBuffer<1024>(molsView, nullptr, options);
     cudaDeviceSynchronize();
     std::vector<nvMolKit::FlatBitVect<fpSize>> gpuResultsHost(gpuResultsTry2.size());
     gpuResultsTry2.copyToHost(gpuResultsHost);


### PR DESCRIPTION
PR #89 added a cudaStream_t stream parameter to
GetFingerprintsGpuBuffer but did not update callers in tests and benchmarks. Pass nullptr (default stream) to fix the compilation errors.

Files updated:
- tests/test_morgan_fingerprint.cpp (4 call sites)
- tests/integration/test_fp_sim_workflow.cpp (1 call site)
- benchmarks/morgan_fp.cpp (6 call sites)