### PR TITLE
Add conformer RMSD docs and fix MMFF benchmark build after API change

### DIFF
--- a/benchmarks/mmff_multimol_bench.cpp
+++ b/benchmarks/mmff_multimol_bench.cpp
@@ -110,7 +110,9 @@ std::vector<std::vector<double>> runNvMolKit(std::vector<RDKit::ROMol*>& molsPtr
                           ", batch_size=" + std::to_string(batchSize) +
                           ", num_concurrent_batches=" + std::to_string(batchesPerGpu) + ", backend=" + backendStr;
   ankerl::nanobench::Bench().epochIterations(1).epochs(1).run(benchName, [&]() {
-    energies = nvMolKit::MMFF::MMFFOptimizeMoleculesConfsBfgs(molsPtrs, maxIters, 100.0, perfOptions, backend);
+    nvMolKit::MMFFProperties properties;
+    properties.nonBondedThreshold = 100.0;
+    energies = nvMolKit::MMFF::MMFFOptimizeMoleculesConfsBfgs(molsPtrs, maxIters, properties, perfOptions, backend);
   });
   return energies;
 }

--- a/docs/api/nvmolkit.rst
+++ b/docs/api/nvmolkit.rst
@@ -76,6 +76,16 @@ Substructure Search
    substructure.SubstructSearchConfig
    substructure.SubstructMatchResults
 
+Conformer RMSD
+--------------
+
+.. autosummary::
+   :toctree: generated/
+   :template: function_template.rst
+
+   conformerRmsd.GetConformerRMSMatrix
+   conformerRmsd.GetConformerRMSMatrixBatch
+
 Types
 -----
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -123,6 +123,8 @@ nvMolKit currently supports the following features:
     * Supports SMILES and recursive SMARTS-based query molecules via RDKit
     * Does not yet support chirality-aware matching, enhanced stereochemistry, or other advanced RDKit ``SubstructMatchParameters`` options
 
+* **Conformer RMSD**: GPU-accelerated pairwise RMSD matrix computation for conformer ensembles
+
 .. _async-results:
 
 Asynchronous GPU Results


### PR DESCRIPTION
Add conformer RMSD to feature list (docs/index.rst) and API reference (docs/api/nvmolkit.rst) — missing since PR #105.

Fix mmff_multimol_bench.cpp build error: MMFFOptimizeMoleculesConfsBfgs now takes MMFFProperties instead of raw nonBondedThreshold (changed in PR #116).