### PR TITLE
 Adds support for `reordering=False` in Butina clustering

### DIFF
--- a/benchmarks/butina_clustering_bench.py
+++ b/benchmarks/butina_clustering_bench.py
@@ -96,10 +96,7 @@ def resize_and_fill_fingerprints(fps: torch.Tensor, want_size: int) -> torch.Ten
 
 
 def bench_rdkit(data, threshold, runs=3, reordering=True):
-    result = time_it(
-        lambda: ClusterData(data, len(data), threshold, isDistData=True, reordering=reordering),
-        runs=runs,
-    )
+    result = time_it(lambda: ClusterData(data, len(data), threshold, isDistData=True, reordering=reordering), runs=runs)
     return result.mean_ms, result.std_ms
 
 
@@ -136,12 +133,7 @@ def bench_rdkit_lowmem(rdkit_fps, threshold, runs=3):
 
 
 def bench_nvmol_inner(data, threshold, neighborlist_max_size, reordering=True):
-    butina_nvmol(
-        data,
-        threshold,
-        neighborlist_max_size=neighborlist_max_size,
-        reordering=reordering,
-    )
+    butina_nvmol(data, threshold, neighborlist_max_size=neighborlist_max_size, reordering=reordering)
 
 
 def bench_nvmol_with_tanimoto(fps, threshold, neighborlist_max_size):
@@ -330,8 +322,7 @@ if __name__ == "__main__":
                     for max_nl in max_nl_sizes:
                         for nvmol_reordering in reordering_modes:
                             print(
-                                "Running nvmolkit_cluster_only "
-                                f"size {size} cutoff {cutoff} max_nl {max_nl} "
+                                f"Running nvmolkit_cluster_only size {size} cutoff {cutoff} max_nl {max_nl} "
                                 f"reordering {nvmol_reordering}"
                             )
                             nvmolkit_cluster_only_result = time_it(
@@ -354,10 +345,7 @@ if __name__ == "__main__":
                                 nvmolkit_with_tanimoto_std = nvmolkit_with_tanimoto_result.std_ms
 
                             nvmol_res = butina_nvmol(
-                                dist_mat,
-                                cutoff,
-                                neighborlist_max_size=max_nl,
-                                reordering=nvmol_reordering,
+                                dist_mat, cutoff, neighborlist_max_size=max_nl, reordering=nvmol_reordering
                             ).torch()
                             torch.cuda.synchronize()
                             nvmol_clusts = [

--- a/benchmarks/butina_clustering_bench.py
+++ b/benchmarks/butina_clustering_bench.py
@@ -95,8 +95,11 @@ def resize_and_fill_fingerprints(fps: torch.Tensor, want_size: int) -> torch.Ten
     return full_fps
 
 
-def bench_rdkit(data, threshold, runs=3):
-    result = time_it(lambda: ClusterData(data, len(data), threshold, isDistData=True, reordering=True), runs=runs)
+def bench_rdkit(data, threshold, runs=3, reordering=True):
+    result = time_it(
+        lambda: ClusterData(data, len(data), threshold, isDistData=True, reordering=reordering),
+        runs=runs,
+    )
     return result.mean_ms, result.std_ms
 
 
@@ -132,8 +135,13 @@ def bench_rdkit_lowmem(rdkit_fps, threshold, runs=3):
     return result.mean_ms, result.std_ms
 
 
-def bench_nvmol_inner(data, threshold, neighborlist_max_size):
-    butina_nvmol(data, threshold, neighborlist_max_size=neighborlist_max_size)
+def bench_nvmol_inner(data, threshold, neighborlist_max_size, reordering=True):
+    butina_nvmol(
+        data,
+        threshold,
+        neighborlist_max_size=neighborlist_max_size,
+        reordering=reordering,
+    )
 
 
 def bench_nvmol_with_tanimoto(fps, threshold, neighborlist_max_size):
@@ -166,6 +174,12 @@ if __name__ == "__main__":
         help="Path to JSON config file specifying per-size benchmark selection",
     )
     parser.add_argument("--cutoff", type=float, default=None, help="Run only this cutoff value")
+    parser.add_argument(
+        "--nvmolkit-reordering",
+        choices=["true", "false", "both"],
+        default="true",
+        help="nvMolKit Butina reordering mode(s) to benchmark (default: true)",
+    )
     parser.add_argument("--runs", type=int, default=3, help="Number of timed repetitions (default: 3)")
     parser.add_argument("--seed", type=int, default=42, help="Random seed for sampling SMILES (default: 42)")
     parser.add_argument(
@@ -308,54 +322,71 @@ if __name__ == "__main__":
                     fused_time, fused_std = fused_result.mean_ms, fused_result.std_ms
 
                 if "nvmolkit" in runs:
+                    reordering_modes = []
+                    if args.nvmolkit_reordering in ("true", "both"):
+                        reordering_modes.append(True)
+                    if args.nvmolkit_reordering in ("false", "both"):
+                        reordering_modes.append(False)
                     for max_nl in max_nl_sizes:
-                        print(f"Running nvmolkit_cluster_only size {size} cutoff {cutoff} max_nl {max_nl}")
-                        nvmolkit_cluster_only_result = time_it(
-                            lambda: bench_nvmol_inner(dist_mat, cutoff, max_nl),
-                            gpu_sync=True,
-                            runs=n_runs,
-                        )
-                        nvmolkit_cluster_only_time = nvmolkit_cluster_only_result.mean_ms
-                        nvmolkit_cluster_only_std = nvmolkit_cluster_only_result.std_ms
-
-                        nvmolkit_with_tanimoto_time, nvmolkit_with_tanimoto_std = float("nan"), float("nan")
-                        if fps_mat_real is not None:
-                            print(f"Running nvmolkit_with_tanimoto size {size} cutoff {cutoff} max_nl {max_nl}")
-                            nvmolkit_with_tanimoto_result = time_it(
-                                lambda: bench_nvmol_with_tanimoto(fps_mat_real, cutoff, max_nl),
+                        for nvmol_reordering in reordering_modes:
+                            print(
+                                "Running nvmolkit_cluster_only "
+                                f"size {size} cutoff {cutoff} max_nl {max_nl} "
+                                f"reordering {nvmol_reordering}"
+                            )
+                            nvmolkit_cluster_only_result = time_it(
+                                lambda: bench_nvmol_inner(dist_mat, cutoff, max_nl, nvmol_reordering),
                                 gpu_sync=True,
                                 runs=n_runs,
                             )
-                            nvmolkit_with_tanimoto_time = nvmolkit_with_tanimoto_result.mean_ms
-                            nvmolkit_with_tanimoto_std = nvmolkit_with_tanimoto_result.std_ms
+                            nvmolkit_cluster_only_time = nvmolkit_cluster_only_result.mean_ms
+                            nvmolkit_cluster_only_std = nvmolkit_cluster_only_result.std_ms
 
-                        nvmol_res = butina_nvmol(dist_mat, cutoff, neighborlist_max_size=max_nl).torch()
-                        torch.cuda.synchronize()
-                        nvmol_clusts = [
-                            tuple(torch.argwhere(nvmol_res == i).flatten().tolist())
-                            for i in range(nvmol_res.max() + 1)
-                        ]
-                        check_butina_correctness(dist_mat <= cutoff, nvmol_clusts)
+                            nvmolkit_with_tanimoto_time, nvmolkit_with_tanimoto_std = float("nan"), float("nan")
+                            if fps_mat_real is not None and nvmol_reordering:
+                                print(f"Running nvmolkit_with_tanimoto size {size} cutoff {cutoff} max_nl {max_nl}")
+                                nvmolkit_with_tanimoto_result = time_it(
+                                    lambda: bench_nvmol_with_tanimoto(fps_mat_real, cutoff, max_nl),
+                                    gpu_sync=True,
+                                    runs=n_runs,
+                                )
+                                nvmolkit_with_tanimoto_time = nvmolkit_with_tanimoto_result.mean_ms
+                                nvmolkit_with_tanimoto_std = nvmolkit_with_tanimoto_result.std_ms
 
-                        results.append(
-                            {
-                                "size": size,
-                                "cutoff": cutoff,
-                                "max_neighborlist_size": max_nl,
-                                "rdkit_cluster_only_time_ms": rdkit_cluster_only_time,
-                                "rdkit_cluster_only_std_ms": rdkit_cluster_only_std,
-                                "rdkit_with_tanimoto_time_ms": rdkit_with_tanimoto_time,
-                                "rdkit_with_tanimoto_std_ms": rdkit_with_tanimoto_std,
-                                "rdkit_lowmem_time_ms": rdkit_lm_time,
-                                "rdkit_lowmem_std_ms": rdkit_lm_std,
-                                "nvmolkit_cluster_only_time_ms": nvmolkit_cluster_only_time,
-                                "nvmolkit_cluster_only_std_ms": nvmolkit_cluster_only_std,
-                                "nvmolkit_with_tanimoto_time_ms": nvmolkit_with_tanimoto_time,
-                                "nvmolkit_with_tanimoto_std_ms": nvmolkit_with_tanimoto_std,
-                                "fused_butina_time_ms": fused_time,
-                                "fused_butina_std_ms": fused_std,
-                            }
-                        )
+                            nvmol_res = butina_nvmol(
+                                dist_mat,
+                                cutoff,
+                                neighborlist_max_size=max_nl,
+                                reordering=nvmol_reordering,
+                            ).torch()
+                            torch.cuda.synchronize()
+                            nvmol_clusts = [
+                                tuple(torch.argwhere(nvmol_res == i).flatten().tolist())
+                                for i in range(nvmol_res.max() + 1)
+                            ]
+                            if nvmol_reordering:
+                                check_butina_correctness(dist_mat <= cutoff, nvmol_clusts)
+
+                            results.append(
+                                {
+                                    "size": size,
+                                    "cutoff": cutoff,
+                                    "max_neighborlist_size": max_nl,
+                                    "nvmolkit_reordering": nvmol_reordering,
+                                    "rdkit_cluster_only_time_ms": rdkit_cluster_only_time,
+                                    "rdkit_cluster_only_std_ms": rdkit_cluster_only_std,
+                                    "rdkit_with_tanimoto_time_ms": rdkit_with_tanimoto_time,
+                                    "rdkit_with_tanimoto_std_ms": rdkit_with_tanimoto_std,
+                                    "rdkit_lowmem_time_ms": rdkit_lm_time,
+                                    "rdkit_lowmem_std_ms": rdkit_lm_std,
+                                    "nvmolkit_cluster_only_time_ms": nvmolkit_cluster_only_time,
+                                    "nvmolkit_cluster_only_std_ms": nvmolkit_cluster_only_std,
+                                    "nvmolkit_with_tanimoto_time_ms": nvmolkit_with_tanimoto_time,
+                                    "nvmolkit_with_tanimoto_std_ms": nvmolkit_with_tanimoto_std,
+                                    "fused_butina_time_ms": fused_time,
+                                    "fused_butina_std_ms": fused_std,
+                                }
+                            )
                 else:
                     results.append(
                         {

--- a/nvmolkit/clustering.cpp
+++ b/nvmolkit/clustering.cpp
@@ -43,7 +43,7 @@ BOOST_PYTHON_MODULE(_clustering) {
       if (!streamOpt) {
         throw std::invalid_argument("Invalid CUDA stream");
       }
-      auto                             stream                = *streamOpt;
+      auto                             stream  = *streamOpt;
       // Extract boost::python::tuple from dict['shape']
       boost::python::tuple             shape   = boost::python::extract<boost::python::tuple>(distanceMatrix["shape"]);
       const size_t                     matDim1 = boost::python::extract<size_t>(shape[0]);
@@ -58,13 +58,8 @@ BOOST_PYTHON_MODULE(_clustering) {
         centroids.setStream(stream);
       }
       const auto centroidSpan = returnCentroids ? toSpan(centroids) : cuda::std::span<int>{};
-      const int numClusters = nvMolKit::butinaGpu(matSpan,
-                                                  toSpan(clusterIds),
-                                                  cutoff,
-                                                  neighborlistMaxSize,
-                                                  centroidSpan,
-                                                  stream,
-                                                  reordering);
+      const int numClusters =
+        nvMolKit::butinaGpu(matSpan, toSpan(clusterIds), cutoff, neighborlistMaxSize, centroidSpan, stream, reordering);
       if (returnCentroids) {
         auto clusterArray  = nvMolKit::makePyArray(clusterIds, boost::python::make_tuple(matDim1));
         auto centroidArray = nvMolKit::makePyArray(centroids, boost::python::make_tuple(numClusters));

--- a/nvmolkit/clustering.cpp
+++ b/nvmolkit/clustering.cpp
@@ -37,8 +37,8 @@ BOOST_PYTHON_MODULE(_clustering) {
         const double               cutoff,
         const int                  neighborlistMaxSize,
         const bool                 returnCentroids,
-        std::uintptr_t             streamPtr,
-        const bool                 reordering) -> boost::python::object {
+        const bool                 reordering,
+        std::uintptr_t             streamPtr) -> boost::python::object {
       auto streamOpt = nvMolKit::acquireExternalStream(streamPtr);
       if (!streamOpt) {
         throw std::invalid_argument("Invalid CUDA stream");
@@ -58,8 +58,8 @@ BOOST_PYTHON_MODULE(_clustering) {
         centroids.setStream(stream);
       }
       const auto centroidSpan = returnCentroids ? toSpan(centroids) : cuda::std::span<int>{};
-      const int numClusters =
-        nvMolKit::butinaGpu(matSpan, toSpan(clusterIds), cutoff, neighborlistMaxSize, centroidSpan, stream, reordering);
+      const int  numClusters =
+        nvMolKit::butinaGpu(matSpan, toSpan(clusterIds), cutoff, neighborlistMaxSize, centroidSpan, reordering, stream);
       if (returnCentroids) {
         auto clusterArray  = nvMolKit::makePyArray(clusterIds, boost::python::make_tuple(matDim1));
         auto centroidArray = nvMolKit::makePyArray(centroids, boost::python::make_tuple(numClusters));
@@ -72,6 +72,6 @@ BOOST_PYTHON_MODULE(_clustering) {
      boost::python::arg("cutoff"),
      boost::python::arg("neighborlist_max_size") = 64,
      boost::python::arg("return_centroids")      = false,
-     boost::python::arg("stream")                = 0,
-     boost::python::arg("reordering")            = true));
+     boost::python::arg("reordering")            = true,
+     boost::python::arg("stream")                = 0));
 };

--- a/nvmolkit/clustering.cpp
+++ b/nvmolkit/clustering.cpp
@@ -37,12 +37,13 @@ BOOST_PYTHON_MODULE(_clustering) {
         const double               cutoff,
         const int                  neighborlistMaxSize,
         const bool                 returnCentroids,
-        std::uintptr_t             streamPtr) -> boost::python::object {
+        std::uintptr_t             streamPtr,
+        const bool                 reordering) -> boost::python::object {
       auto streamOpt = nvMolKit::acquireExternalStream(streamPtr);
       if (!streamOpt) {
         throw std::invalid_argument("Invalid CUDA stream");
       }
-      auto                             stream  = *streamOpt;
+      auto                             stream                = *streamOpt;
       // Extract boost::python::tuple from dict['shape']
       boost::python::tuple             shape   = boost::python::extract<boost::python::tuple>(distanceMatrix["shape"]);
       const size_t                     matDim1 = boost::python::extract<size_t>(shape[0]);
@@ -55,13 +56,19 @@ BOOST_PYTHON_MODULE(_clustering) {
       if (returnCentroids) {
         centroids.resize(matDim1);
         centroids.setStream(stream);
-        const int numClusters =
-          nvMolKit::butinaGpu(matSpan, toSpan(clusterIds), cutoff, neighborlistMaxSize, toSpan(centroids), stream);
+      }
+      const auto centroidSpan = returnCentroids ? toSpan(centroids) : cuda::std::span<int>{};
+      const int numClusters = nvMolKit::butinaGpu(matSpan,
+                                                  toSpan(clusterIds),
+                                                  cutoff,
+                                                  neighborlistMaxSize,
+                                                  centroidSpan,
+                                                  stream,
+                                                  reordering);
+      if (returnCentroids) {
         auto clusterArray  = nvMolKit::makePyArray(clusterIds, boost::python::make_tuple(matDim1));
         auto centroidArray = nvMolKit::makePyArray(centroids, boost::python::make_tuple(numClusters));
         return boost::python::make_tuple(toOwnedPyArray(clusterArray), toOwnedPyArray(centroidArray));
-      } else {
-        nvMolKit::butinaGpu(matSpan, toSpan(clusterIds), cutoff, neighborlistMaxSize, {}, stream);
       }
 
       return toOwnedPyArray(nvMolKit::makePyArray(clusterIds, boost::python::make_tuple(matDim1)));
@@ -70,5 +77,6 @@ BOOST_PYTHON_MODULE(_clustering) {
      boost::python::arg("cutoff"),
      boost::python::arg("neighborlist_max_size") = 64,
      boost::python::arg("return_centroids")      = false,
-     boost::python::arg("stream")                = 0));
+     boost::python::arg("stream")                = 0,
+     boost::python::arg("reordering")            = true));
 };

--- a/nvmolkit/clustering.py
+++ b/nvmolkit/clustering.py
@@ -78,8 +78,8 @@ def butina(
                               shared memory.
         return_centroids: Whether to return centroid indices for each cluster.
         reordering: Whether to update neighbor counts among unassigned items
-                    after each cluster is formed. The default matches the
-                    existing nvMolKit behavior and RDKit's ``reordering=True``.
+                    after each cluster is formed. Defaults to True, while
+                    RDKit's ``Butina.ClusterData`` defaults to False.
         stream: CUDA stream to use. If None, uses the current stream.
 
     Returns:

--- a/nvmolkit/clustering.py
+++ b/nvmolkit/clustering.py
@@ -54,6 +54,7 @@ def butina(
     neighborlist_max_size: int = 64,
     return_centroids: bool = False,
     stream: torch.cuda.Stream | None = None,
+    reordering: bool = True,
 ) -> AsyncGpuResult | tuple[AsyncGpuResult, AsyncGpuResult]:
     """Perform Butina clustering on a distance matrix.
 
@@ -70,13 +71,16 @@ def butina(
                         CPU tensors and NumPy arrays are copied to CUDA. Inputs
                         must have dtype float64.
         cutoff: Distance threshold for clustering. Items are neighbors if their
-                distance is less than this cutoff.
+                distance is less than or equal to this cutoff.
         neighborlist_max_size: Maximum size of the neighborlist used for small cluster
                               optimization. Must be 8, 16, 24, 32, 64, or 128. Larger values
                               allow parallel processing of larger clusters but use more
                               shared memory.
         return_centroids: Whether to return centroid indices for each cluster.
         stream: CUDA stream to use. If None, uses the current stream.
+        reordering: Whether to update neighbor counts among unassigned items
+                    after each cluster is formed. The default matches the
+                    existing nvMolKit behavior and RDKit's ``reordering=True``.
 
     Returns:
         AsyncGpuResult of shape ``(N,)`` with cluster IDs (cluster 0 is the
@@ -102,6 +106,7 @@ def butina(
             neighborlist_max_size,
             return_centroids,
             active_stream.cuda_stream,
+            reordering,
         )
     if return_centroids:
         clusters, centroids = result

--- a/nvmolkit/clustering.py
+++ b/nvmolkit/clustering.py
@@ -53,8 +53,8 @@ def butina(
     cutoff: float,
     neighborlist_max_size: int = 64,
     return_centroids: bool = False,
-    stream: torch.cuda.Stream | None = None,
     reordering: bool = True,
+    stream: torch.cuda.Stream | None = None,
 ) -> AsyncGpuResult | tuple[AsyncGpuResult, AsyncGpuResult]:
     """Perform Butina clustering on a distance matrix.
 
@@ -77,10 +77,10 @@ def butina(
                               allow parallel processing of larger clusters but use more
                               shared memory.
         return_centroids: Whether to return centroid indices for each cluster.
-        stream: CUDA stream to use. If None, uses the current stream.
         reordering: Whether to update neighbor counts among unassigned items
                     after each cluster is formed. The default matches the
                     existing nvMolKit behavior and RDKit's ``reordering=True``.
+        stream: CUDA stream to use. If None, uses the current stream.
 
     Returns:
         AsyncGpuResult of shape ``(N,)`` with cluster IDs (cluster 0 is the
@@ -105,8 +105,8 @@ def butina(
             cutoff,
             neighborlist_max_size,
             return_centroids,
-            active_stream.cuda_stream,
             reordering,
+            active_stream.cuda_stream,
         )
     if return_centroids:
         clusters, centroids = result

--- a/nvmolkit/tests/test_clustering.py
+++ b/nvmolkit/tests/test_clustering.py
@@ -16,10 +16,10 @@
 import numpy as np
 import pytest
 import torch
+from rdkit.ML.Cluster.Butina import ClusterData
 
 from nvmolkit.clustering import butina, fused_butina
 from nvmolkit.types import AsyncGpuResult
-
 
 def check_butina_correctness(hit_mat, clusts):
     hit_mat = hit_mat.clone()
@@ -50,6 +50,52 @@ def check_butina_correctness(hit_mat, clusts):
             hit_mat[item, :] = False
             hit_mat[:, item] = False
     assert len(seen) == hit_mat.shape[0]
+
+
+def _nvmolkit_butina_clusters(distance_matrix, cutoff, *, reordering):
+    labels, centroids = butina(
+        torch.tensor(distance_matrix, device="cuda"),
+        cutoff,
+        reordering=reordering,
+        return_centroids=True,
+    )
+    labels = labels.torch().cpu().numpy()
+    centroids = centroids.torch().cpu().numpy()
+
+    clusters = []
+    for cluster_id, centroid in enumerate(centroids):
+        members = np.flatnonzero(labels == cluster_id)
+        clusters.append(tuple([int(centroid)] + [int(member) for member in members if member != centroid]))
+    return tuple(clusters)
+
+
+def _rdkit_butina_clusters(distance_matrix, cutoff, *, reordering):
+    return ClusterData(
+        np.asarray(distance_matrix, dtype=np.float64),
+        int(distance_matrix.shape[0]),
+        cutoff,
+        isDistData=True,
+        reordering=reordering,
+    )
+
+
+@pytest.mark.parametrize("reordering", [False, True])
+def test_butina_reordering_matches_rdkit(reordering):
+    distance_matrix = np.array(
+        [
+            [0.0, 0.2, 1.0, 1.0],
+            [0.2, 0.0, 0.2, 1.0],
+            [1.0, 0.2, 0.0, 0.2],
+            [1.0, 1.0, 0.2, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    cutoff = 0.2
+
+    expected = _rdkit_butina_clusters(distance_matrix, cutoff, reordering=reordering)
+    got = _nvmolkit_butina_clusters(distance_matrix, cutoff, reordering=reordering)
+
+    assert got == expected
 
 
 @pytest.mark.parametrize(

--- a/src/butina.cu
+++ b/src/butina.cu
@@ -490,7 +490,7 @@ void sortFixedOrderCandidates(const cuda::std::span<const int> hitCounts,
                                            sizeof(uint64_t) * 8,
                                            stream);
 
-  // 2) allocate the temp memory (note that even though the allocatoin is async, we are using the same stream
+  // 2) allocate the temp memory (note that even though the allocation is async, we are using the same stream
   // so FIFO order is maintained and mem will be allocated before the next sorting step)
   const AsyncDeviceVector<uint8_t> sortTemp(sortTempBytes, stream);
 
@@ -506,7 +506,7 @@ void sortFixedOrderCandidates(const cuda::std::span<const int> hitCounts,
   cudaCheckError(cudaGetLastError());
 }
 
-// Select the next fixed-order centroid. We can actually parallelize this kernel. We use block sizes of 1024 and process
+// Select the next fixed-order centroid. We use fixedOrderPrepareBlockSize threads and process
 // the vector chunk by chunk (processing of each chunk is parallelized).
 __global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uint64_t> sortedKeys,
                                                  const cuda::std::span<const int>      hitCounts,
@@ -620,7 +620,7 @@ __global__ void assignFixedOrderActiveRowKernel(const cuda::std::span<const uint
   const int numPoints = clusters.size();
   const int tid       = blockIdx.x * blockDim.x + threadIdx.x;
   if (tid == 0) {
-    // We make the selected point the centroid and assing it to a cluster
+    // We make the selected point the centroid and assign it to a cluster.
     clusters[pointIdx] = clusterVal;
     if (!centroids.empty()) {
       // This is only filled when the caller requests centroids.

--- a/src/butina.cu
+++ b/src/butina.cu
@@ -447,6 +447,140 @@ void renumberClustersBySize(const cuda::std::span<int> clusters,
   }
 }
 
+// Build packed sort keys: higher hit count (primary key), then higher point index (secondary key). Note that we can easily use a bit mask after radix sort to retrieve the point idxs. Bits 0-31 will be for hit count, Bits 32-63 will be for point idxs.
+__global__ void setupFixedOrderSortKeysKernel(const cuda::std::span<const int> hitCounts,
+                                              const cuda::std::span<uint64_t>  sortKeys) {
+  const int numPoints = hitCounts.size();
+  const int idx       = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < numPoints) {
+    const uint64_t count = hitCounts[idx];
+    const uint64_t point = idx;
+    sortKeys[idx]        = (count << 32) | point;
+  }
+}
+
+// Sort candidates once
+void sortFixedOrderCandidates(const cuda::std::span<const int> hitCounts,
+                              const cuda::std::span<uint64_t>  sortKeys,
+                              const cuda::std::span<uint64_t>  sortedKeys,
+                              cudaStream_t                     stream) {
+  const int numPoints = hitCounts.size();
+  if (numPoints == 0) {
+    return;
+  }
+
+  constexpr int blockSize = 256;
+
+  // make enough blocks so that we have enough threads for radix sort
+  const int     numBlocks = (numPoints + blockSize - 1) / blockSize;
+  setupFixedOrderSortKeysKernel<<<numBlocks, blockSize, 0, stream>>>(hitCounts, sortKeys);
+  cudaCheckError(cudaGetLastError());
+
+  std::size_t sortTempBytes = 0;
+
+  // 1) find how much temp memory is needed for the radix sort (nullptr passed in as parameter)
+  cub::DeviceRadixSort::SortKeysDescending(
+    nullptr, sortTempBytes, sortKeys.data(), sortedKeys.data(), numPoints, 0, sizeof(uint64_t) * 8, stream);
+
+  // 2) allocate the temp memory (note that even though the allocatoin is async, we are using the same stream
+  // so FIFO order is maintained and mem will be allocated before the next sorting step)
+  const AsyncDeviceVector<uint8_t> sortTemp(sortTempBytes, stream);
+
+  // 3) run the radix sort
+  cub::DeviceRadixSort::SortKeysDescending(
+    sortTemp.data(), sortTempBytes, sortKeys.data(), sortedKeys.data(), numPoints, 0, sizeof(uint64_t) * 8, stream);
+  cudaCheckError(cudaGetLastError());
+}
+
+// Select the next unassigned candidate for parallel row assignment. Note that this task is not inherently parallelizable. We walk the vector element by element until we find a valid centroid. If done in parallel, we could accidentallly select the wrong elements as centroids.
+__global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uint64_t> sortedKeys,
+                                                 const cuda::std::span<const int> hitCounts,
+                                                 const cuda::std::span<int>       clusters,
+                                                 const cuda::std::span<int>       centroids,
+                                                 int*                             cursor,
+                                                 int*                             activePoint,
+                                                 int*                             activeCluster,
+                                                 int*                             nextClusterIdx,
+                                                 int*                             keepGoing) {
+  const int numPoints = clusters.size();
+  if (threadIdx.x != 0 || blockIdx.x != 0) {
+    return;
+  }
+
+  *activePoint   = -1;
+  *activeCluster = -1;
+
+  while (*cursor < numPoints) {
+    // use the bit mask to get the point index
+    const int pointIdx = sortedKeys[*cursor] & 0xffffffffULL;
+    *cursor += 1;
+
+    // this point has already been assigned to a cluster, cannot be a centroid
+    if (clusters[pointIdx] > -1) {
+      continue;
+    }
+
+    const int clusterVal = *nextClusterIdx;
+    *nextClusterIdx += 1;
+    clusters[pointIdx] = clusterVal;
+
+    // this is here if the caller decides to request the centroids list
+    if (!centroids.empty()) {
+      centroids[clusterVal] = pointIdx;
+    }
+
+    // we prepare the parameters for the parallel scan.
+    if (hitCounts[pointIdx] > 1) {
+      *activePoint   = pointIdx;
+      *activeCluster = clusterVal;
+      *keepGoing     = 1;
+      return;
+    }
+  }
+
+  *keepGoing = 0;
+}
+
+// Parallel Scan. Assign still-unassigned neighbors to the cluster belonging to the centroid we just selected
+__global__ void assignFixedOrderActiveRowKernel(const cuda::std::span<const uint8_t> hitMatrix,
+                                                const cuda::std::span<int>           clusters,
+                                                const int*                           activePoint,
+                                                const int*                           activeCluster) {
+  const int pointIdx   = *activePoint;
+  const int clusterVal = *activeCluster;
+  if (pointIdx < 0 || clusterVal < 0) {
+    return;
+  }
+
+  const int    numPoints = clusters.size();
+  const int    tid       = blockIdx.x * blockDim.x + threadIdx.x;
+  const cuda::std::span<const uint8_t> hits = hitMatrix.subspan(static_cast<size_t>(pointIdx) * numPoints, numPoints);
+
+  // if this point is a neighbor of the selected centroid and we have not yet selected a cluster for this point, assign this point to the same cluster as the centroid we just selected
+  if (tid < numPoints && hits[tid] && clusters[tid] < 0) {
+    clusters[tid] = clusterVal;
+  }
+}
+
+// Update the graph WHILE condition.
+__global__ void checkFixedOrderGraphConditionKernel(cudaGraphConditionalHandle handle, const int* keepGoing) {
+  cudaGraphSetConditional(handle, (*keepGoing != 0) ? 1 : 0);
+}
+
+void validateButinaInputs(const cuda::std::span<const uint8_t> hitMatrix,
+                          const cuda::std::span<int>           clusters,
+                          const cuda::std::span<int>           centroids) {
+  const size_t numPoints = clusters.size();
+  if (!centroids.empty() && centroids.size() != numPoints) {
+    throw std::invalid_argument("Centroids size mismatch: " + std::to_string(centroids.size()) +
+                                " != " + std::to_string(numPoints));
+  }
+  if (const size_t matSize = hitMatrix.size(); numPoints * numPoints != matSize) {
+    throw std::runtime_error("Butina size mismatch" + std::to_string(numPoints) +
+                             " points^2 != " + std::to_string(matSize) + " neighbor matrix size");
+  }
+}
+
 }  // namespace
 
 #if CUB_VERSION < 200800
@@ -910,6 +1044,139 @@ void buildInitialNeighborlist(const int                            numPoints,
   cudaCheckError(cudaStreamSynchronize(stream));
 }
 
+//! CUDA Graph wrapper for the reordering=false loop.
+class FixedOrderButinaGraph {
+ public:
+  FixedOrderButinaGraph(const cuda::std::span<const uint8_t> hitMatrix,
+                        const cuda::std::span<const uint64_t> sortedKeys,
+                        const cuda::std::span<const int>     hitCounts,
+                        const cuda::std::span<int>           clusters,
+                        const cuda::std::span<int>           centroids,
+                        int*                                 cursorPtr,
+                        int*                                 activePointPtr,
+                        int*                                 activeClusterPtr,
+                        int*                                 clusterIdxPtr,
+                        int*                                 keepGoingPtr) {
+    const int numPoints     = clusters.size();
+    const int rowScanBlocks = (numPoints + blockSizeCount - 1) / blockSizeCount;
+
+    cudaCheckError(cudaGraphCreate(&graph_, 0));
+    cudaCheckError(cudaGraphConditionalHandleCreate(&handle_, graph_, 1, cudaGraphCondAssignDefault));
+
+    cudaGraphNodeParams cParams = {};
+    cParams.type                = cudaGraphNodeTypeConditional;
+    cParams.conditional.handle  = handle_;
+    cParams.conditional.type    = cudaGraphCondTypeWhile;
+    cParams.conditional.size    = 1;
+    cudaGraphNode_t conditionalNode;
+#if CUDART_VERSION >= 13000
+    cudaCheckError(cudaGraphAddNode(&conditionalNode, graph_, nullptr, nullptr, 0, &cParams));
+#else
+    cudaCheckError(cudaGraphAddNode(&conditionalNode, graph_, nullptr, 0, &cParams));
+#endif
+
+    cudaGraph_t bodyGraph = cParams.conditional.phGraph_out[0];
+    cudaStream_t captureStream;
+    cudaCheckError(cudaStreamCreate(&captureStream));
+    cudaCheckError(
+      cudaStreamBeginCaptureToGraph(captureStream, bodyGraph, nullptr, nullptr, 0, cudaStreamCaptureModeRelaxed));
+
+    prepareFixedOrderCandidateKernel<<<1, 1, 0, captureStream>>>(sortedKeys,
+                                                                  hitCounts,
+                                                                  clusters,
+                                                                  centroids,
+                                                                  cursorPtr,
+                                                                  activePointPtr,
+                                                                  activeClusterPtr,
+                                                                  clusterIdxPtr,
+                                                                  keepGoingPtr);
+    cudaCheckError(cudaGetLastError());
+
+    assignFixedOrderActiveRowKernel<<<rowScanBlocks, blockSizeCount, 0, captureStream>>>(hitMatrix,
+                                                                                         clusters,
+                                                                                         activePointPtr,
+                                                                                         activeClusterPtr);
+    cudaCheckError(cudaGetLastError());
+
+    checkFixedOrderGraphConditionKernel<<<1, 1, 0, captureStream>>>(handle_, keepGoingPtr);
+    cudaCheckError(cudaGetLastError());
+
+    cudaCheckError(cudaStreamEndCapture(captureStream, nullptr));
+    cudaCheckError(cudaStreamDestroy(captureStream));
+    cudaCheckError(cudaGraphInstantiate(&graphExec_, graph_, nullptr, nullptr, 0));
+  }
+
+  ~FixedOrderButinaGraph() {
+    if (graphExec_) {
+      cudaGraphExecDestroy(graphExec_);
+    }
+    if (graph_) {
+      cudaGraphDestroy(graph_);
+    }
+  }
+
+  void launch(cudaStream_t stream) { cudaCheckError(cudaGraphLaunch(graphExec_, stream)); }
+
+ private:
+  cudaGraph_t                graph_     = nullptr;
+  cudaGraphExec_t            graphExec_ = nullptr;
+  cudaGraphConditionalHandle handle_    = {};
+};
+
+//! Run fixed-order Butina clustering for reordering=false.
+int butinaGpuNoReorderingImpl(const cuda::std::span<const uint8_t> hitMatrix,
+                              const cuda::std::span<int>           clusters,
+                              const cuda::std::span<int>           centroids,
+                              const cuda::std::span<int>           initialHitCounts,
+                              cudaStream_t                         stream) {
+  ScopedNvtxRange setupRange("Butina No-Reordering Setup");
+
+  // validate input
+  const int       numPoints = clusters.size();
+  validateButinaInputs(hitMatrix, clusters, centroids);
+  if (numPoints == 0) {
+    return 0;
+  }
+
+  // sort the points
+  AsyncDeviceVector<uint64_t> sortKeys(numPoints, stream);
+  AsyncDeviceVector<uint64_t> sortedKeys(numPoints, stream);
+  sortFixedOrderCandidates(initialHitCounts, toSpan(sortKeys), toSpan(sortedKeys), stream);
+
+  const AsyncDevicePtr<int> clusterIdx(0, stream);
+  setupRange.pop();
+
+  const AsyncDevicePtr<int> cursor(0, stream);
+  const AsyncDevicePtr<int> activePoint(-1, stream);
+  const AsyncDevicePtr<int> activeCluster(-1, stream);
+  const AsyncDevicePtr<int> keepGoing(1, stream);
+
+  ScopedNvtxRange       buildRange("Build no-reordering Butina graph");
+  FixedOrderButinaGraph graph(hitMatrix,
+                              toSpan(sortedKeys),
+                              initialHitCounts,
+                              clusters,
+                              centroids,
+                              cursor.data(),
+                              activePoint.data(),
+                              activeCluster.data(),
+                              clusterIdx.data(),
+                              keepGoing.data());
+  buildRange.pop();
+
+  const ScopedNvtxRange loopRange("No-reordering Butina graph loop");
+  graph.launch(stream);
+
+  // we pin this host memory since it allows us to more efficiently copy data from the device back to host again
+  PinnedHostVector<int> numClusters(1);
+  cudaCheckError(cudaMemcpyAsync(numClusters.data(), clusterIdx.data(), sizeof(int), cudaMemcpyDefault, stream));
+
+  // wait for the memcpy to finish
+  cudaCheckError(cudaStreamSynchronize(stream));
+
+  return numClusters[0];
+}
+
 template <int NeighborlistMaxSize>
 [[maybe_unused]] int butinaGpuImpl(const cuda::std::span<const uint8_t> hitMatrix,
                                    const cuda::std::span<int>           clusters,
@@ -917,15 +1184,8 @@ template <int NeighborlistMaxSize>
                                    cudaStream_t                         stream) {
   ScopedNvtxRange setupRange("Butina Setup");
   const size_t    numPoints = clusters.size();
-  if (!centroids.empty() && centroids.size() != numPoints) {
-    throw std::invalid_argument("Centroids size mismatch: " + std::to_string(centroids.size()) +
-                                " != " + std::to_string(numPoints));
-  }
+  validateButinaInputs(hitMatrix, clusters, centroids);
   setAll(clusters, -1, stream);
-  if (const size_t matSize = hitMatrix.size(); numPoints * numPoints != matSize) {
-    throw std::runtime_error("Butina size mismatch" + std::to_string(numPoints) +
-                             " points^2 != " + std::to_string(matSize) + " neighbor matrix size");
-  }
   AsyncDeviceVector<int> clusterSizes(clusters.size(), stream);
   clusterSizes.zero();
   AsyncDeviceVector<int> neighborList(NeighborlistMaxSize * numPoints, stream);
@@ -1018,7 +1278,20 @@ template <int NeighborlistMaxSize>
                                const cuda::std::span<int>           clusters,
                                const int                            neighborlistMaxSize,
                                const cuda::std::span<int>           centroids,
-                               cudaStream_t                         stream) {
+                               cudaStream_t                         stream,
+                               const bool                           reordering) {
+  if (!reordering) {
+    AsyncDeviceVector<int> initialHitCounts(clusters.size(), stream);
+    if (!clusters.empty()) {
+      setAll(clusters, -1, stream);
+      butinaKernelCountClusterSize<<<clusters.size(), blockSizeCount, 0, stream>>>(hitMatrix,
+                                                                                   clusters,
+                                                                                   toSpan(initialHitCounts));
+      cudaCheckError(cudaGetLastError());
+    }
+    return butinaGpuNoReorderingImpl(hitMatrix, clusters, centroids, toSpan(initialHitCounts), stream);
+  }
+
   switch (neighborlistMaxSize) {
     case 8:
       return butinaGpuImpl<8>(hitMatrix, clusters, centroids, stream);
@@ -1050,6 +1323,26 @@ __global__ void thresholdDistanceMatrixKernel(const double* __restrict__ matrix,
   }
 }
 
+// Build the uint8_t hit matrix and fixed-order counts in one pass.
+__global__ void thresholdDistanceMatrixAndCountKernel(const cuda::std::span<const double> matrix,
+                                                      const cuda::std::span<uint8_t>      hits,
+                                                      const cuda::std::span<int>          hitCounts,
+                                                      const double                        cutoff) {
+  const int tid       = threadIdx.x;
+  const int pointIdx  = blockIdx.x;
+  const int numPoints = hitCounts.size();
+  int       localCount = 0;
+  for (int i = tid; i < numPoints; i += blockSizeCount) {
+    const size_t idx = static_cast<size_t>(pointIdx) * numPoints + i;
+    const bool   hit = matrix[idx] <= cutoff;
+    hits[idx]        = hit;
+    if (hit) {
+      localCount++;
+    }
+  }
+  sumCountsAndStoreClusterSize(tid, pointIdx, hitCounts, localCount);
+}
+
 }  // namespace
 
 [[maybe_unused]] int butinaGpu(const cuda::std::span<const double> distanceMatrix,
@@ -1057,17 +1350,29 @@ __global__ void thresholdDistanceMatrixKernel(const double* __restrict__ matrix,
                                const double                        cutoff,
                                const int                           neighborlistMaxSize,
                                const cuda::std::span<int>          centroids,
-                               cudaStream_t                        stream) {
+                               cudaStream_t                        stream,
+                               const bool                          reordering) {
   AsyncDeviceVector<uint8_t> hitMatrix(distanceMatrix.size(), stream);
 
-  constexpr int blockSize = 256;
-  const size_t  numBlocks = (distanceMatrix.size() + blockSize - 1) / blockSize;
-  thresholdDistanceMatrixKernel<<<numBlocks, blockSize, 0, stream>>>(distanceMatrix.data(),
-                                                                     hitMatrix.data(),
-                                                                     cutoff,
-                                                                     distanceMatrix.size());
-  cudaCheckError(cudaGetLastError());
-  return butinaGpu(toSpan(hitMatrix), clusters, neighborlistMaxSize, centroids, stream);
+  if (reordering) {
+    constexpr int blockSize = 256;
+    const size_t  numBlocks = (distanceMatrix.size() + blockSize - 1) / blockSize;
+    thresholdDistanceMatrixKernel<<<numBlocks, blockSize, 0, stream>>>(distanceMatrix.data(),
+                                                                       hitMatrix.data(),
+                                                                       cutoff,
+                                                                       distanceMatrix.size());
+    cudaCheckError(cudaGetLastError());
+    return butinaGpu(toSpan(hitMatrix), clusters, neighborlistMaxSize, centroids, stream, reordering);
+  }
+
+  AsyncDeviceVector<int> initialHitCounts(clusters.size(), stream);
+  if (!clusters.empty()) {
+    setAll(clusters, -1, stream);
+    thresholdDistanceMatrixAndCountKernel<<<clusters.size(), blockSizeCount, 0, stream>>>(
+      distanceMatrix, toSpan(hitMatrix), toSpan(initialHitCounts), cutoff);
+    cudaCheckError(cudaGetLastError());
+  }
+  return butinaGpuNoReorderingImpl(toSpan(hitMatrix), clusters, centroids, toSpan(initialHitCounts), stream);
 }
 
 }  // namespace nvMolKit

--- a/src/butina.cu
+++ b/src/butina.cu
@@ -537,7 +537,7 @@ __global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uin
   while (base < numPoints) {
     const int sortedPos = base + tid;
 
-    // INT_MAX will be used as identity later when we do the block reduce with cub::Min()
+    // INT_MAX will be used as identity later when we do the block reduce with cubMin()
     int candidate = INT_MAX;
 
     if (sortedPos < numPoints) {
@@ -552,7 +552,7 @@ __global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uin
     // now we reduce all those indexes and get the smallest one (corresponds to first valid element in the sorted hit
     // count vector)
     const int reducedFirstPos =
-      cub::BlockReduce<int, fixedOrderPrepareBlockSize>(tempStorage).Reduce(candidate, cub::Min());
+      cub::BlockReduce<int, fixedOrderPrepareBlockSize>(tempStorage).Reduce(candidate, cubMin());
     if (tid == 0) {
       firstPos = reducedFirstPos;
     }

--- a/src/butina.cu
+++ b/src/butina.cu
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <climits>
 
 #include <cooperative_groups.h>
 
@@ -30,6 +31,7 @@ namespace nvMolKit {
 
 namespace {
 constexpr int blockSizeCount            = 256;
+constexpr int fixedOrderPrepareBlockSize = 1024;
 constexpr int kSubTileSize              = 8;
 constexpr int kMinLoopSizeForAssignment = 2;
 
@@ -492,58 +494,85 @@ void sortFixedOrderCandidates(const cuda::std::span<const int> hitCounts,
   cudaCheckError(cudaGetLastError());
 }
 
-// Select the next unassigned candidate for parallel row assignment. Note that this task is not inherently parallelizable. We walk the vector element by element until we find a valid centroid. If done in parallel, we could accidentallly select the wrong elements as centroids.
+// ! Add custom kernel support if some users cant use CUB like was previously done earlier
+// Select the next fixed-order centroid. The order is sequential, but each block pass can search a chunk in parallel.
 __global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uint64_t> sortedKeys,
-                                                 const cuda::std::span<const int> hitCounts,
                                                  const cuda::std::span<int>       clusters,
-                                                 const cuda::std::span<int>       centroids,
                                                  int*                             cursor,
                                                  int*                             activePoint,
                                                  int*                             activeCluster,
                                                  int*                             nextClusterIdx,
                                                  int*                             keepGoing) {
   const int numPoints = clusters.size();
-  if (threadIdx.x != 0 || blockIdx.x != 0) {
+  const int tid       = threadIdx.x;
+
+  // we should only be launching this kernel with only one block regardless
+  if (blockIdx.x != 0) {
     return;
   }
 
-  *activePoint   = -1;
-  *activeCluster = -1;
+  __shared__ cub::BlockReduce<int, fixedOrderPrepareBlockSize>::TempStorage tempStorage;
 
-  while (*cursor < numPoints) {
-    // use the bit mask to get the point index
-    const int pointIdx = sortedKeys[*cursor] & 0xffffffffULL;
-    *cursor += 1;
+  if (tid == 0) {
+    *activePoint   = -1;
+    *activeCluster = -1;
+  }
 
-    // this point has already been assigned to a cluster, cannot be a centroid
-    if (clusters[pointIdx] > -1) {
+  int base = *cursor;
+  while (base < numPoints) {
+    const int sortedPos = base + tid;
+
+    // INT_MAX will be used as identity later when we do the block reduce with min()
+    int candidate = INT_MAX;
+
+    if (sortedPos < numPoints) {
+      // Use the bit mask to get the point index from the packed sort key.
+      const int pointIdx = sortedKeys[sortedPos] & 0xffffffffULL;
+      // Points already assigned to a cluster cannot become centroids.
+      if (clusters[pointIdx] < 0) {
+        candidate = sortedPos;
+      }
+    }
+
+    // now we reduce all those indexes and get the smallest one (corresponds to first valid element in the sorted hit count vector)
+    const int firstPos = cub::BlockReduce<int, fixedOrderPrepareBlockSize>(tempStorage).Reduce(candidate, cub::Min());
+    if (firstPos == INT_MAX) {
+      // we have not yet found a valid candidate
+      base += fixedOrderPrepareBlockSize;
+
+      // this sync is necessary, (need to ensure all threads extracted the reduced value from shared memory, before
+      // calling blockReduce again and potentially overwriting shared memory)
+      __syncthreads();
       continue;
     }
 
-    const int clusterVal = *nextClusterIdx;
-    *nextClusterIdx += 1;
-    clusters[pointIdx] = clusterVal;
+    const int pointIdx = sortedKeys[firstPos] & 0xffffffffULL;
+    if (tid == 0) {
+      // update the cursor all the way to the next possible valid idx
+      *cursor = firstPos + 1;
 
-    // this is here if the caller decides to request the centroids list
-    if (!centroids.empty()) {
-      centroids[clusterVal] = pointIdx;
-    }
+      const int clusterVal = *nextClusterIdx;
+      *nextClusterIdx += 1;
 
-    // we prepare the parameters for the parallel scan.
-    if (hitCounts[pointIdx] > 1) {
+      // Prepare the parameters for the parallel row scan.
       *activePoint   = pointIdx;
       *activeCluster = clusterVal;
       *keepGoing     = 1;
-      return;
     }
+    return;
   }
 
-  *keepGoing = 0;
+  if (tid == 0) {
+    *cursor    = numPoints;
+    *keepGoing = 0;
+  }
 }
 
 // Parallel Scan. Assign still-unassigned neighbors to the cluster belonging to the centroid we just selected
 __global__ void assignFixedOrderActiveRowKernel(const cuda::std::span<const uint8_t> hitMatrix,
+                                                const cuda::std::span<const int>     hitCounts,
                                                 const cuda::std::span<int>           clusters,
+                                                const cuda::std::span<int>           centroids,
                                                 const int*                           activePoint,
                                                 const int*                           activeCluster) {
   const int pointIdx   = *activePoint;
@@ -554,6 +583,20 @@ __global__ void assignFixedOrderActiveRowKernel(const cuda::std::span<const uint
 
   const int    numPoints = clusters.size();
   const int    tid       = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid == 0) {
+    // We make the selected point the centroid and assing it to a cluster
+    clusters[pointIdx] = clusterVal;
+    if (!centroids.empty()) {
+      // This is only filled when the caller requests centroids.
+      centroids[clusterVal] = pointIdx;
+    }
+  }
+
+  // If hit_count == 1, no neighbors to scan this point only hit itself
+  if (hitCounts[pointIdx] <= 1) {
+    return;
+  }
+
   const cuda::std::span<const uint8_t> hits = hitMatrix.subspan(static_cast<size_t>(pointIdx) * numPoints, numPoints);
 
   // if this point is a neighbor of the selected centroid and we have not yet selected a cluster for this point, assign this point to the same cluster as the centroid we just selected
@@ -1081,19 +1124,19 @@ class FixedOrderButinaGraph {
     cudaCheckError(
       cudaStreamBeginCaptureToGraph(captureStream, bodyGraph, nullptr, nullptr, 0, cudaStreamCaptureModeRelaxed));
 
-    prepareFixedOrderCandidateKernel<<<1, 1, 0, captureStream>>>(sortedKeys,
-                                                                  hitCounts,
-                                                                  clusters,
-                                                                  centroids,
-                                                                  cursorPtr,
-                                                                  activePointPtr,
-                                                                  activeClusterPtr,
-                                                                  clusterIdxPtr,
-                                                                  keepGoingPtr);
+    prepareFixedOrderCandidateKernel<<<1, fixedOrderPrepareBlockSize, 0, captureStream>>>(sortedKeys,
+                                                                                          clusters,
+                                                                                          cursorPtr,
+                                                                                          activePointPtr,
+                                                                                          activeClusterPtr,
+                                                                                          clusterIdxPtr,
+                                                                                          keepGoingPtr);
     cudaCheckError(cudaGetLastError());
 
     assignFixedOrderActiveRowKernel<<<rowScanBlocks, blockSizeCount, 0, captureStream>>>(hitMatrix,
+                                                                                         hitCounts,
                                                                                          clusters,
+                                                                                         centroids,
                                                                                          activePointPtr,
                                                                                          activeClusterPtr);
     cudaCheckError(cudaGetLastError());

--- a/src/butina.cu
+++ b/src/butina.cu
@@ -30,7 +30,7 @@ namespace nvMolKit {
 
 namespace {
 constexpr int blockSizeCount             = 256;
-constexpr int fixedOrderPrepareBlockSize = 1024;
+constexpr int fixedOrderPrepareBlockSize = 512;
 constexpr int kSubTileSize               = 8;
 constexpr int kMinLoopSizeForAssignment  = 2;
 
@@ -461,7 +461,7 @@ __global__ void setupFixedOrderSortKeysKernel(const cuda::std::span<const int> h
   }
 }
 
-// Sort candidates once
+// Sort candidates once. Only one sort needed since this kernel will be used for the reordering = False version of clustering
 void sortFixedOrderCandidates(const cuda::std::span<const int> hitCounts,
                               const cuda::std::span<uint64_t>  sortKeys,
                               const cuda::std::span<uint64_t>  sortedKeys,
@@ -509,7 +509,9 @@ void sortFixedOrderCandidates(const cuda::std::span<const int> hitCounts,
 // Select the next fixed-order centroid. We can actually parallelize this kernel. We use block sizes of 1024 and process
 // the vector chunk by chunk (processing of each chunk is parallelized).
 __global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uint64_t> sortedKeys,
+                                                 const cuda::std::span<const int>      hitCounts,
                                                  const cuda::std::span<int>            clusters,
+                                                 const cuda::std::span<int>            centroids,
                                                  int*                                  cursor,
                                                  int*                                  activePoint,
                                                  int*                                  activeCluster,
@@ -518,7 +520,7 @@ __global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uin
   const int numPoints = clusters.size();
   const int tid       = threadIdx.x;
 
-  // we should only be launching this kernel with only one block regardless
+  // we should be launching this kernel with only one block regardless
   if (blockIdx.x != 0) {
     return;
   }
@@ -535,7 +537,7 @@ __global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uin
   while (base < numPoints) {
     const int sortedPos = base + tid;
 
-    // INT_MAX will be used as identity later when we do the block reduce with min()
+    // INT_MAX will be used as identity later when we do the block reduce with cub::Min()
     int candidate = INT_MAX;
 
     if (sortedPos < numPoints) {
@@ -564,7 +566,9 @@ __global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uin
       continue;
     }
 
-    const int pointIdx = sortedKeys[firstPos] & 0xffffffffULL;
+    const int pointIdx     = sortedKeys[firstPos] & 0xffffffffULL;
+    bool      hasNeighbors = hitCounts[pointIdx] > 1;
+
     if (tid == 0) {
       // update the cursor all the way to the next possible valid idx
       *cursor = firstPos + 1;
@@ -572,15 +576,28 @@ __global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uin
       const int clusterVal = *nextClusterIdx;
       *nextClusterIdx += 1;
 
-      // Prepare the parameters for the parallel row scan.
-      *activePoint   = pointIdx;
-      *activeCluster = clusterVal;
-      *keepGoing     = 1;
+      if (hasNeighbors) {
+        // Prepare the parameters for the parallel row scan.
+        *activePoint   = pointIdx;
+        *activeCluster = clusterVal;
+        *keepGoing     = 1;
+      } else {
+        // this is a singleton, no need for the parallel row scan, we can instantly assign the cluster
+        clusters[pointIdx] = clusterVal;
+        if (!centroids.empty()) {
+          centroids[clusterVal] = pointIdx;
+        }
+      }
     }
-    return;
+
+    // threads should exit to run the parallel row scan
+    if (hasNeighbors) {
+      return;
+    }
+
+    base = firstPos + 1;
   }
 
-  // we have processed the whole arr
   if (tid == 0) {
     *cursor    = numPoints;
     *keepGoing = 0;
@@ -1145,7 +1162,9 @@ class FixedOrderButinaGraph {
       cudaStreamBeginCaptureToGraph(captureStream, bodyGraph, nullptr, nullptr, 0, cudaStreamCaptureModeRelaxed));
 
     prepareFixedOrderCandidateKernel<<<1, fixedOrderPrepareBlockSize, 0, captureStream>>>(sortedKeys,
+                                                                                          hitCounts,
                                                                                           clusters,
+                                                                                          centroids,
                                                                                           cursorPtr,
                                                                                           activePointPtr,
                                                                                           activeClusterPtr,

--- a/src/butina.cu
+++ b/src/butina.cu
@@ -12,10 +12,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <climits>
-
 #include <cooperative_groups.h>
 
+#include <climits>
 #include <cub/cub.cuh>
 
 #include "src/butina.h"
@@ -30,10 +29,10 @@
 namespace nvMolKit {
 
 namespace {
-constexpr int blockSizeCount            = 256;
+constexpr int blockSizeCount             = 256;
 constexpr int fixedOrderPrepareBlockSize = 1024;
-constexpr int kSubTileSize              = 8;
-constexpr int kMinLoopSizeForAssignment = 2;
+constexpr int kSubTileSize               = 8;
+constexpr int kMinLoopSizeForAssignment  = 2;
 
 __device__ __forceinline__ void sumCountsAndStoreClusterSize(const int                  tid,
                                                              const int                  pointIdx,
@@ -449,7 +448,8 @@ void renumberClustersBySize(const cuda::std::span<int> clusters,
   }
 }
 
-// Build packed sort keys: higher hit count (primary key), then higher point index (secondary key). Note that we can easily use a bit mask after radix sort to retrieve the point idxs. Bits 0-31 will be for hit count, Bits 32-63 will be for point idxs.
+// Build packed sort keys: higher hit count (primary key), then higher point index (secondary key).
+// Bits 32-63 hold the hit count; bits 0-31 hold the point index and can be recovered with a bit mask.
 __global__ void setupFixedOrderSortKeysKernel(const cuda::std::span<const int> hitCounts,
                                               const cuda::std::span<uint64_t>  sortKeys) {
   const int numPoints = hitCounts.size();
@@ -474,35 +474,47 @@ void sortFixedOrderCandidates(const cuda::std::span<const int> hitCounts,
   constexpr int blockSize = 256;
 
   // make enough blocks so that we have enough threads for radix sort
-  const int     numBlocks = (numPoints + blockSize - 1) / blockSize;
+  const int numBlocks = (numPoints + blockSize - 1) / blockSize;
   setupFixedOrderSortKeysKernel<<<numBlocks, blockSize, 0, stream>>>(hitCounts, sortKeys);
   cudaCheckError(cudaGetLastError());
 
   std::size_t sortTempBytes = 0;
 
   // 1) find how much temp memory is needed for the radix sort (nullptr passed in as parameter)
-  cub::DeviceRadixSort::SortKeysDescending(
-    nullptr, sortTempBytes, sortKeys.data(), sortedKeys.data(), numPoints, 0, sizeof(uint64_t) * 8, stream);
+  cub::DeviceRadixSort::SortKeysDescending(nullptr,
+                                           sortTempBytes,
+                                           sortKeys.data(),
+                                           sortedKeys.data(),
+                                           numPoints,
+                                           0,
+                                           sizeof(uint64_t) * 8,
+                                           stream);
 
   // 2) allocate the temp memory (note that even though the allocatoin is async, we are using the same stream
   // so FIFO order is maintained and mem will be allocated before the next sorting step)
   const AsyncDeviceVector<uint8_t> sortTemp(sortTempBytes, stream);
 
   // 3) run the radix sort
-  cub::DeviceRadixSort::SortKeysDescending(
-    sortTemp.data(), sortTempBytes, sortKeys.data(), sortedKeys.data(), numPoints, 0, sizeof(uint64_t) * 8, stream);
+  cub::DeviceRadixSort::SortKeysDescending(sortTemp.data(),
+                                           sortTempBytes,
+                                           sortKeys.data(),
+                                           sortedKeys.data(),
+                                           numPoints,
+                                           0,
+                                           sizeof(uint64_t) * 8,
+                                           stream);
   cudaCheckError(cudaGetLastError());
 }
 
-// ! Add custom kernel support if some users cant use CUB like was previously done earlier
-// Select the next fixed-order centroid. The order is sequential, but each block pass can search a chunk in parallel.
+// Select the next fixed-order centroid. We can actually parallelize this kernel. We use block sizes of 1024 and process
+// the vector chunk by chunk (processing of each chunk is parallelized).
 __global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uint64_t> sortedKeys,
-                                                 const cuda::std::span<int>       clusters,
-                                                 int*                             cursor,
-                                                 int*                             activePoint,
-                                                 int*                             activeCluster,
-                                                 int*                             nextClusterIdx,
-                                                 int*                             keepGoing) {
+                                                 const cuda::std::span<int>            clusters,
+                                                 int*                                  cursor,
+                                                 int*                                  activePoint,
+                                                 int*                                  activeCluster,
+                                                 int*                                  nextClusterIdx,
+                                                 int*                                  keepGoing) {
   const int numPoints = clusters.size();
   const int tid       = threadIdx.x;
 
@@ -512,6 +524,7 @@ __global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uin
   }
 
   __shared__ cub::BlockReduce<int, fixedOrderPrepareBlockSize>::TempStorage tempStorage;
+  __shared__ int                                                            firstPos;
 
   if (tid == 0) {
     *activePoint   = -1;
@@ -534,15 +547,20 @@ __global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uin
       }
     }
 
-    // now we reduce all those indexes and get the smallest one (corresponds to first valid element in the sorted hit count vector)
-    const int firstPos = cub::BlockReduce<int, fixedOrderPrepareBlockSize>(tempStorage).Reduce(candidate, cub::Min());
+    // now we reduce all those indexes and get the smallest one (corresponds to first valid element in the sorted hit
+    // count vector)
+    const int reducedFirstPos =
+      cub::BlockReduce<int, fixedOrderPrepareBlockSize>(tempStorage).Reduce(candidate, cub::Min());
+    if (tid == 0) {
+      firstPos = reducedFirstPos;
+    }
+    // sync is necessary for 1) allows us to reuse temp storage the next while loop iteration with no issues, 2) tid==0
+    // shares the reduced value with the other threads
+    __syncthreads();
+
     if (firstPos == INT_MAX) {
       // we have not yet found a valid candidate
       base += fixedOrderPrepareBlockSize;
-
-      // this sync is necessary, (need to ensure all threads extracted the reduced value from shared memory, before
-      // calling blockReduce again and potentially overwriting shared memory)
-      __syncthreads();
       continue;
     }
 
@@ -562,6 +580,7 @@ __global__ void prepareFixedOrderCandidateKernel(const cuda::std::span<const uin
     return;
   }
 
+  // we have processed the whole arr
   if (tid == 0) {
     *cursor    = numPoints;
     *keepGoing = 0;
@@ -581,8 +600,8 @@ __global__ void assignFixedOrderActiveRowKernel(const cuda::std::span<const uint
     return;
   }
 
-  const int    numPoints = clusters.size();
-  const int    tid       = blockIdx.x * blockDim.x + threadIdx.x;
+  const int numPoints = clusters.size();
+  const int tid       = blockIdx.x * blockDim.x + threadIdx.x;
   if (tid == 0) {
     // We make the selected point the centroid and assing it to a cluster
     clusters[pointIdx] = clusterVal;
@@ -599,7 +618,8 @@ __global__ void assignFixedOrderActiveRowKernel(const cuda::std::span<const uint
 
   const cuda::std::span<const uint8_t> hits = hitMatrix.subspan(static_cast<size_t>(pointIdx) * numPoints, numPoints);
 
-  // if this point is a neighbor of the selected centroid and we have not yet selected a cluster for this point, assign this point to the same cluster as the centroid we just selected
+  // if this point is a neighbor of the selected centroid and we have not yet selected a cluster for this point, assign
+  // this point to the same cluster as the centroid we just selected
   if (tid < numPoints && hits[tid] && clusters[tid] < 0) {
     clusters[tid] = clusterVal;
   }
@@ -1090,16 +1110,16 @@ void buildInitialNeighborlist(const int                            numPoints,
 //! CUDA Graph wrapper for the reordering=false loop.
 class FixedOrderButinaGraph {
  public:
-  FixedOrderButinaGraph(const cuda::std::span<const uint8_t> hitMatrix,
+  FixedOrderButinaGraph(const cuda::std::span<const uint8_t>  hitMatrix,
                         const cuda::std::span<const uint64_t> sortedKeys,
-                        const cuda::std::span<const int>     hitCounts,
-                        const cuda::std::span<int>           clusters,
-                        const cuda::std::span<int>           centroids,
-                        int*                                 cursorPtr,
-                        int*                                 activePointPtr,
-                        int*                                 activeClusterPtr,
-                        int*                                 clusterIdxPtr,
-                        int*                                 keepGoingPtr) {
+                        const cuda::std::span<const int>      hitCounts,
+                        const cuda::std::span<int>            clusters,
+                        const cuda::std::span<int>            centroids,
+                        int*                                  cursorPtr,
+                        int*                                  activePointPtr,
+                        int*                                  activeClusterPtr,
+                        int*                                  clusterIdxPtr,
+                        int*                                  keepGoingPtr) {
     const int numPoints     = clusters.size();
     const int rowScanBlocks = (numPoints + blockSizeCount - 1) / blockSizeCount;
 
@@ -1118,7 +1138,7 @@ class FixedOrderButinaGraph {
     cudaCheckError(cudaGraphAddNode(&conditionalNode, graph_, nullptr, 0, &cParams));
 #endif
 
-    cudaGraph_t bodyGraph = cParams.conditional.phGraph_out[0];
+    cudaGraph_t  bodyGraph = cParams.conditional.phGraph_out[0];
     cudaStream_t captureStream;
     cudaCheckError(cudaStreamCreate(&captureStream));
     cudaCheckError(
@@ -1175,7 +1195,7 @@ int butinaGpuNoReorderingImpl(const cuda::std::span<const uint8_t> hitMatrix,
   ScopedNvtxRange setupRange("Butina No-Reordering Setup");
 
   // validate input
-  const int       numPoints = clusters.size();
+  const int numPoints = clusters.size();
   validateButinaInputs(hitMatrix, clusters, centroids);
   if (numPoints == 0) {
     return 0;
@@ -1321,8 +1341,8 @@ template <int NeighborlistMaxSize>
                                const cuda::std::span<int>           clusters,
                                const int                            neighborlistMaxSize,
                                const cuda::std::span<int>           centroids,
-                               cudaStream_t                         stream,
-                               const bool                           reordering) {
+                               const bool                           reordering,
+                               cudaStream_t                         stream) {
   if (!reordering) {
     AsyncDeviceVector<int> initialHitCounts(clusters.size(), stream);
     if (!clusters.empty()) {
@@ -1371,9 +1391,9 @@ __global__ void thresholdDistanceMatrixAndCountKernel(const cuda::std::span<cons
                                                       const cuda::std::span<uint8_t>      hits,
                                                       const cuda::std::span<int>          hitCounts,
                                                       const double                        cutoff) {
-  const int tid       = threadIdx.x;
-  const int pointIdx  = blockIdx.x;
-  const int numPoints = hitCounts.size();
+  const int tid        = threadIdx.x;
+  const int pointIdx   = blockIdx.x;
+  const int numPoints  = hitCounts.size();
   int       localCount = 0;
   for (int i = tid; i < numPoints; i += blockSizeCount) {
     const size_t idx = static_cast<size_t>(pointIdx) * numPoints + i;
@@ -1393,8 +1413,8 @@ __global__ void thresholdDistanceMatrixAndCountKernel(const cuda::std::span<cons
                                const double                        cutoff,
                                const int                           neighborlistMaxSize,
                                const cuda::std::span<int>          centroids,
-                               cudaStream_t                        stream,
-                               const bool                          reordering) {
+                               const bool                          reordering,
+                               cudaStream_t                        stream) {
   AsyncDeviceVector<uint8_t> hitMatrix(distanceMatrix.size(), stream);
 
   if (reordering) {
@@ -1405,14 +1425,16 @@ __global__ void thresholdDistanceMatrixAndCountKernel(const cuda::std::span<cons
                                                                        cutoff,
                                                                        distanceMatrix.size());
     cudaCheckError(cudaGetLastError());
-    return butinaGpu(toSpan(hitMatrix), clusters, neighborlistMaxSize, centroids, stream, reordering);
+    return butinaGpu(toSpan(hitMatrix), clusters, neighborlistMaxSize, centroids, reordering, stream);
   }
 
   AsyncDeviceVector<int> initialHitCounts(clusters.size(), stream);
   if (!clusters.empty()) {
     setAll(clusters, -1, stream);
-    thresholdDistanceMatrixAndCountKernel<<<clusters.size(), blockSizeCount, 0, stream>>>(
-      distanceMatrix, toSpan(hitMatrix), toSpan(initialHitCounts), cutoff);
+    thresholdDistanceMatrixAndCountKernel<<<clusters.size(), blockSizeCount, 0, stream>>>(distanceMatrix,
+                                                                                          toSpan(hitMatrix),
+                                                                                          toSpan(initialHitCounts),
+                                                                                          cutoff);
     cudaCheckError(cudaGetLastError());
   }
   return butinaGpuNoReorderingImpl(toSpan(hitMatrix), clusters, centroids, toSpan(initialHitCounts), stream);

--- a/src/butina.h
+++ b/src/butina.h
@@ -32,7 +32,7 @@ namespace nvMolKit {
  *                       contains the distance between items i and j.
  * @param clusters Output array of size N. Each element will contain the cluster ID for
  *                 that item. Modified in-place.
- * @param cutoff Distance threshold for clustering. Items with distance < cutoff are
+ * @param cutoff Distance threshold for clustering. Items with distance <= cutoff are
  *               considered neighbors.
  * @param neighborlistMaxSize Maximum size of the neighborlist used for small cluster optimization.
  *                            Must be 8, 16, 24, 32, 64, or 128. Larger values allow parallel
@@ -40,6 +40,7 @@ namespace nvMolKit {
  * @param centroids Optional output array of size N. If provided, centroids[i] stores the
  *                  centroid index for cluster i. Must be empty or size N.
  * @param stream CUDA stream to execute operations on. Defaults to stream 0.
+ * @param reordering Whether to dynamically reorder candidates after each cluster assignment.
  * @return Number of clusters assigned.
  */
 [[maybe_unused]] int butinaGpu(cuda::std::span<const double> distanceMatrix,
@@ -47,7 +48,8 @@ namespace nvMolKit {
                                double                        cutoff,
                                int                           neighborlistMaxSize = 64,
                                cuda::std::span<int>          centroids           = {},
-                               cudaStream_t                  stream              = nullptr);
+                               cudaStream_t                  stream              = nullptr,
+                               bool                          reordering          = true);
 
 /**
  * @brief Perform Butina clustering on a precomputed hit matrix.
@@ -56,7 +58,7 @@ namespace nvMolKit {
  * a binary hit matrix where element (i,j) indicates whether items i and j are neighbors.
  *
  * @param hitMatrix Binary matrix of size NxN where hitMatrix[i*N+j] = 1 if items i and j
- *                  are neighbors (distance < cutoff), 0 otherwise.
+ *                  are neighbors, 0 otherwise.
  * @param clusters Output array of size N. Each element will contain the cluster ID for
  *                 that item. Modified in-place.
  * @param neighborlistMaxSize Maximum size of the neighborlist used for small cluster optimization.
@@ -65,13 +67,15 @@ namespace nvMolKit {
  * @param centroids Optional output array of size N. If provided, centroids[i] stores the
  *                  centroid index for cluster i. Must be empty or size N.
  * @param stream CUDA stream to execute operations on. Defaults to stream 0.
+ * @param reordering Whether to dynamically reorder candidates after each cluster assignment.
  * @return Number of clusters assigned.
  */
 [[maybe_unused]] int butinaGpu(cuda::std::span<const uint8_t> hitMatrix,
                                cuda::std::span<int>           clusters,
                                int                            neighborlistMaxSize = 64,
                                cuda::std::span<int>           centroids           = {},
-                               cudaStream_t                   stream              = nullptr);
+                               cudaStream_t                   stream              = nullptr,
+                               bool                           reordering          = true);
 }  // namespace nvMolKit
 
 #endif  // NVMOLKIT_BUTINA_H

--- a/src/butina.h
+++ b/src/butina.h
@@ -39,8 +39,8 @@ namespace nvMolKit {
  *                            processing of larger clusters but use more memory.
  * @param centroids Optional output array of size N. If provided, centroids[i] stores the
  *                  centroid index for cluster i. Must be empty or size N.
- * @param stream CUDA stream to execute operations on. Defaults to stream 0.
  * @param reordering Whether to dynamically reorder candidates after each cluster assignment.
+ * @param stream CUDA stream to execute operations on. Defaults to stream 0.
  * @return Number of clusters assigned.
  */
 [[maybe_unused]] int butinaGpu(cuda::std::span<const double> distanceMatrix,
@@ -48,8 +48,8 @@ namespace nvMolKit {
                                double                        cutoff,
                                int                           neighborlistMaxSize = 64,
                                cuda::std::span<int>          centroids           = {},
-                               cudaStream_t                  stream              = nullptr,
-                               bool                          reordering          = true);
+                               bool                          reordering          = true,
+                               cudaStream_t                  stream              = nullptr);
 
 /**
  * @brief Perform Butina clustering on a precomputed hit matrix.
@@ -66,16 +66,16 @@ namespace nvMolKit {
  *                            processing of larger clusters but use more memory.
  * @param centroids Optional output array of size N. If provided, centroids[i] stores the
  *                  centroid index for cluster i. Must be empty or size N.
- * @param stream CUDA stream to execute operations on. Defaults to stream 0.
  * @param reordering Whether to dynamically reorder candidates after each cluster assignment.
+ * @param stream CUDA stream to execute operations on. Defaults to stream 0.
  * @return Number of clusters assigned.
  */
 [[maybe_unused]] int butinaGpu(cuda::std::span<const uint8_t> hitMatrix,
                                cuda::std::span<int>           clusters,
                                int                            neighborlistMaxSize = 64,
                                cuda::std::span<int>           centroids           = {},
-                               cudaStream_t                   stream              = nullptr,
-                               bool                           reordering          = true);
+                               bool                           reordering          = true,
+                               cudaStream_t                   stream              = nullptr);
 }  // namespace nvMolKit
 
 #endif  // NVMOLKIT_BUTINA_H

--- a/src/butina.h
+++ b/src/butina.h
@@ -58,7 +58,7 @@ namespace nvMolKit {
  * a binary hit matrix where element (i,j) indicates whether items i and j are neighbors.
  *
  * @param hitMatrix Binary matrix of size NxN where hitMatrix[i*N+j] = 1 if items i and j
- *                  are neighbors, 0 otherwise.
+ *                  are neighbors (distance <= cutoff), 0 otherwise.
  * @param clusters Output array of size N. Each element will contain the cluster ID for
  *                 that item. Modified in-place.
  * @param neighborlistMaxSize Maximum size of the neighborlist used for small cluster optimization.

--- a/tests/test_butina.cpp
+++ b/tests/test_butina.cpp
@@ -63,7 +63,7 @@ std::pair<std::vector<int>, int> runButina(const std::vector<double>& distances,
   AsyncDeviceVector<int>    resultDev(nPts, stream);
   distancesDev.copyFromHost(distances);
   const int numClusters =
-    nvMolKit::butinaGpu(toSpan(distancesDev), toSpan(resultDev), cutoff, neighborlistMaxSize, {}, stream);
+    nvMolKit::butinaGpu(toSpan(distancesDev), toSpan(resultDev), cutoff, neighborlistMaxSize, {}, true, stream);
   std::vector<int> got(nPts);
   resultDev.copyToHost(got);
   cudaStreamSynchronize(stream);
@@ -84,6 +84,7 @@ std::tuple<std::vector<int>, std::vector<int>, int> runButinaWithCentroids(const
                                               cutoff,
                                               neighborlistMaxSize,
                                               toSpan(centroidsDev),
+                                              true,
                                               stream);
   std::vector<int> got(nPts);
   std::vector<int> centroids(nPts);
@@ -167,7 +168,7 @@ TEST_P(ButinaSinglePointFixture, HandlesSinglePoint) {
   distancesDev.copyFromHost(std::vector<double>{0.0});
 
   const int numClusters =
-    nvMolKit::butinaGpu(toSpan(distancesDev), toSpan(resultDev), cutoff, neighborlistMaxSize, {}, stream);
+    nvMolKit::butinaGpu(toSpan(distancesDev), toSpan(resultDev), cutoff, neighborlistMaxSize, {}, true, stream);
   std::vector<int> got(nPts);
   resultDev.copyToHost(got);
   cudaStreamSynchronize(stream);


### PR DESCRIPTION
## Summary

  Adds support for `reordering=False` in Butina clustering.  Fixes #192 

  ## Changes

  - Added a `reordering` option to the Python and C++ Butina APIs.
  - Implemented fixed-order Butina clustering for `reordering=False`.
  - Added tests and ensured they passed
  - Updated the benchmark to optionally run nvMolKit Butina with reordering enabled, disabled, or both.
