### PR TITLE
Fix build issues due to CUDA version stuff

### DIFF
--- a/src/fingerprint_similarity_device.cuh
+++ b/src/fingerprint_similarity_device.cuh
@@ -7,9 +7,9 @@
 #include <cuda_runtime.h>
 
 #include <cmath>
-#include <cuda/std/functional>
 
 #include "src/fingerprint_similarity.h"
+#include "src/utils/cub_helpers.cuh"
 
 namespace nvMolKit {
 
@@ -49,8 +49,8 @@ template <FingerprintSimilarityMetric Metric>
 __device__ __forceinline__ bool fingerprintSimilarityCanReach(const int   lhsBitCount,
                                                               const int   rhsBitCount,
                                                               const float threshold) {
-  const int minBitCount = cuda::std::min(lhsBitCount, rhsBitCount);
-  const int maxBitCount = cuda::std::max(lhsBitCount, rhsBitCount);
+  const int minBitCount = cubMin{}(lhsBitCount, rhsBitCount);
+  const int maxBitCount = cubMax{}(lhsBitCount, rhsBitCount);
   if constexpr (Metric == FingerprintSimilarityMetric::Tanimoto) {
     // The intersection cannot exceed the smaller population and the union cannot be smaller than the larger one.
     return static_cast<float>(minBitCount) >= threshold * static_cast<float>(maxBitCount);


### PR DESCRIPTION
### Summary
The fingerprint similarity device helper was using `cuda::std::min` and `cuda::std::max`, but those functions are not exposed consistently across the CUDA/CCCL versions supported. 

This now uses the repo’s existing `cubMin`/`cubMax` helpers, which keeps the code consistent with the rest of the CUDA code. The unused `<cuda/std/functional>` include was also removed.