### PR TITLE
docs: add skill card for nvmolkit-usage

### DIFF
--- a/skills/nvmolkit-usage/skill-card.md
+++ b/skills/nvmolkit-usage/skill-card.md
@@ -1,0 +1,71 @@
+## Description: <br>
+Guides an agent to write correct code against the installed nvMolKit Python API for GPU-accelerated, batched RDKit-style cheminformatics — Morgan fingerprints, Tanimoto/cosine similarity, ETKDG conformer embedding, MMFF/UFF optimization, TFD, conformer RMSD, Butina clustering, and substructure search. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (Kevin Boyd, @scal444) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+Cheminformaticians and ML engineers importing `nvmolkit.*`, debugging an nvMolKit call, deciding between nvMolKit and RDKit for a batched workflow, or wiring nvMolKit results into a torch/numpy pipeline. Out of scope: building nvMolKit from source. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* An existing nvMolKit installation (`uv pip install --torch-backend=cu128 nvmolkit`) <br>
+* CUDA-capable NVIDIA GPU <br>
+* Python with RDKit available for interoperation <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: The skill emits code for the agent or user to execute; incorrect API usage could produce silently wrong cheminformatics results — for example mismatched fingerprint parameters yielding similarity scores that are not comparable across runs. <br>
+Mitigation: The skill documents result types and the asynchronous execution model (`AsyncGpuResult`, `Device3DResult`) explicitly, and includes a verification step to run against the install before writing real code. Users should review generated code before executing it. <br>
+
+Risk: nvMolKit and RDKit can differ numerically for the same nominal operation (conformer generation and force-field optimization are stochastic and hardware-sensitive), so results may not reproduce bit-for-bit across backends. <br>
+Mitigation: The skill covers where nvMolKit is and is not an appropriate substitute for RDKit, so users choose the backend deliberately rather than assuming equivalence. <br>
+
+Risk: Batched GPU operations on large molecule libraries can exhaust GPU memory mid-run. <br>
+Mitigation: The skill documents `HardwareOptions` configuration for batch and device control. <br>
+
+Risk: Asynchronous result handles can be read before completion if the execution model is misunderstood, yielding empty or partial data. <br>
+Mitigation: The skill's result-type documentation is explicit about when a result must be awaited or materialized. <br>
+
+## Reference(s): <br>
+- [nvMolKit repository](https://github.com/NVIDIA-BioNeMo/nvMolKit) <br>
+- [RDKit documentation](https://www.rdkit.org/docs/) — the API surface nvMolKit mirrors <br>
+- `SKILL.md` in this skill directory — result types, `HardwareOptions` / `SubstructSearchConfig`, and worked recipes <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Code, Analysis] <br>
+**Output Format:** [Markdown with inline Python code blocks] <br>
+**Output Parameters:** [1D] <br>
+**Other Properties Related to Output:** [The skill produces code and guidance; it does not itself execute cheminformatics workloads. Generated code should be reviewed before execution.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+11 functional evaluation tasks in `evals/evals.json` covering fingerprinting, similarity, conformer generation, optimization, clustering, and substructure search, plus 2 trigger-activation cases in `evals/trigger_evals.json`. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+ea68428 (source: git SHA, committed 2026-08-03) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/skills/nvmolkit-usage/skill-card.md
+++ b/skills/nvmolkit-usage/skill-card.md
@@ -53,7 +53,7 @@ Mitigation: The skill's result-type documentation is explicit about when a resul
 Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
 
 ## Evaluation Tasks: <br>
-11 functional evaluation tasks in `evals/evals.json` covering fingerprinting, similarity, conformer generation, optimization, clustering, and substructure search, plus 2 trigger-activation cases in `evals/trigger_evals.json`. <br>
+11 functional evaluation tasks in `evals/evals.json` covering fingerprinting, similarity, conformer generation, optimization, clustering, and substructure search, plus 3 trigger-activation cases and 2 non-trigger cases in `evals/trigger_evals.json`. <br>
 
 ## Evaluation Metrics Used: <br>
 Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>


### PR DESCRIPTION
Adds `skills/nvmolkit-usage/skill-card.md`, following the NVIDIA skill card format used across the [NVIDIA/skills](https://github.com/NVIDIA/skills) catalog (326/326 skills there carry one).

## Why

The NVIDIA/skills sync workflow **drops any skill missing `skill-card.md`, `skill.oms.sig`, or an eval dataset** — the enforcement step removes the skill dir before the PR is created, so non-compliant skills never merge into the catalog. The same requirement is tracked as `SRC-11` in `bionemo-agent-toolkit`'s CONTRIBUTING.

State of this repo against those three artifacts:

| Artifact | Status |
|---|---|
| eval dataset | present — 11 functional tasks + 2 trigger cases under `evals/` |
| `skill-card.md` | **this PR** |
| `skill.oms.sig` | outstanding — needs `nvskills-ci` wired here (see below) |

## What's in the card

Description, owner, license, use case, requirements (nvMolKit install, CUDA GPU, RDKit interop), risks and mitigations, references, output types, evaluation, and ethical considerations.

The risk section is specific to what this skill actually is — a code-authoring skill. It covers incorrect API usage producing silently wrong cheminformatics results, numerical divergence from RDKit for stochastic operations (ETKDG, force-field optimization), GPU memory exhaustion on large batched runs, and misuse of the asynchronous result model (`AsyncGpuResult` / `Device3DResult`) yielding partial data.

**Evaluation results are marked pending, not fabricated.** NVSkills-Eval has not been run against this skill; the card states the eval task counts that exist and says results and a `BENCHMARK.md` will follow.

## Still needed after this: signatures

`skill.oms.sig` cannot be added by a PR — it is emitted by the `NVIDIA/nvskills-ci` service. Wiring it here needs a `request-nvskills-ci.yml` workflow, the `NVSKILLS_CI_DISPATCH_TOKEN` secret, and a maintainer commenting `/nvskills-ci` on a PR. This repo already has CI workflows, so it is the smallest lift of the three source repos. Happy to open that as a follow-up.

## Context

`bionemo-agent-toolkit` vendors this skill via `components.d/nvmolkit.yml` and rsyncs with `--delete`, so a card committed there is wiped on the next nightly sync. This repo is the source of truth. The catalog carries an interim copy of this same card in a `compliance.d/` overlay, which is retired automatically once this merges.

Please correct anything I got wrong about the API surface or risks — I wrote this from `SKILL.md` and the repo layout, not from running nvMolKit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
